### PR TITLE
Add reconcile delay

### DIFF
--- a/controllers/patroni_core_controller.go
+++ b/controllers/patroni_core_controller.go
@@ -165,6 +165,8 @@ func (pr *PatroniCoreReconciler) Reconcile(ctx context.Context, request ctrl.Req
 			return reconcile.Result{}, nil
 		}
 	}
+	pr.logger.Info("Reconcile will be started...")
+	time.Sleep(60 * time.Second)
 
 	if pr.errorCounter == 0 {
 		pr.reason = "StartPatroniCoreClusterReconcile"


### PR DESCRIPTION
Reconcile delay has been added in order to prevent reconcile on the old operator during update