### PR TITLE
Postgres operator supporting TLS fix

### DIFF
--- a/charts/patroni-services/templates/deployment.yaml
+++ b/charts/patroni-services/templates/deployment.yaml
@@ -55,6 +55,13 @@ spec:
               readOnly: true
           {{ end }}
           {{ end }}
+          {{- if not .Values.externalDataBase }}
+          {{- if and .Values.tls .Values.tls.enabled }}
+          volumeMounts:
+            - name: tls-cert
+              mountPath: /certs/
+          {{- end }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -122,15 +129,23 @@ spec:
         - name: {{ $v.name }} 
       {{- end }}     
       {{- end }}
+      volumes:
       {{ if .Values.externalDataBase }}
       {{ if eq (lower .Values.externalDataBase.type) "cloudsql"}}
-      volumes:
         - name: cloudsql-instance-credentials
           secret:
             defaultMode: 420
             secretName: {{ default "cloudsql-instance-credentials" .Values.externalDataBase.authSecretName }}
       {{ end }}
       {{ end }}
+      {{- if not .Values.externalDataBase }}
+      {{- if and .Values.tls .Values.tls.enabled }}
+        - name: tls-cert
+          secret:
+            secretName: {{ .Values.tls.certificateSecretName }}
+            defaultMode: 416
+      {{- end }}
+      {{- end }}
       tolerations:
         {{- range $tKey, $t := .Values.policies.tolerations }}
         - key: {{ $t.key }}

--- a/pkg/vault/role_rotator.go
+++ b/pkg/vault/role_rotator.go
@@ -249,6 +249,15 @@ func getOperatorService(operatorName string, namespace string) *corev1.Service {
 					},
 					Name: "rotate",
 				},
+				{
+					Port:     8443,
+					Protocol: corev1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 8443,
+					},
+					Name: "web-tls",
+				},
 			},
 			Selector: label,
 		},


### PR DESCRIPTION
Add new TLS volumeMount and Volume to deployment. Operator server can serve on 8443 port too.