### PR TITLE
Add metric is_db_alive

### DIFF
--- a/charts/patroni-services/monitoring/azure-grafana-dashboard.json
+++ b/charts/patroni-services/monitoring/azure-grafana-dashboard.json
@@ -1175,9 +1175,10 @@
       {
         "allValue": ".+",
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "pg-ssl-test-Flexible",
-          "value": "pg-ssl-test-Flexible"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
- add metric `is_db_alive` to azure grafana dashboard