### PR TITLE
Shm volume mount for major upgrade pod.

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -389,6 +389,7 @@ func (u *Upgrade) ProceedUpgrade(cr *v1.PatroniCore, cluster *v1.PatroniClusterS
 	// copy nodeSelector, Volumes, SecurityContext from Deployment
 	upgradePod.Spec.NodeSelector = patroniDeployment.Spec.Template.Spec.NodeSelector
 	upgradePod.Spec.Volumes = patroniDeployment.Spec.Template.Spec.Volumes
+	upgradePod.Spec.Containers[0].VolumeMounts = patroniDeployment.Spec.Template.Spec.Containers[0].VolumeMounts
 	upgradePod.Spec.SecurityContext = patroniDeployment.Spec.Template.Spec.SecurityContext
 
 	// create pod and wait till completed


### PR DESCRIPTION
Within the scope of this commit, we have made possible to copy shm volume mount for major upgrade pod as well. So, in this case it would be possible for user to perform major upgrade for cluster which has large amount of data.
Without this fix, the major upgrade may fail for large clusters as by default kubernetes provides only 64Mb of shm volume size by default..