### PR TITLE
fixed pgbackrest after major upgrade

### DIFF
--- a/controllers/patroni_core_controller.go
+++ b/controllers/patroni_core_controller.go
@@ -53,6 +53,7 @@ import (
 // PatroniCoreReconciler reconciles a PatroniCore object
 
 var (
+	MasterLabel                   = map[string]string{"pgtype": "master"}
 	patroniCoreOperatorLockCmName = "patroni-core-operator-lock"
 	//pgHost                          = util.GetEnv("POSTGRES_HOST", "pg-patroni")
 )
@@ -308,6 +309,25 @@ func (pr *PatroniCoreReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	if err := pr.AddExcludeLabelToCm(pr.Client, patroniCoreOperatorLockCmName); err != nil {
 		pr.logger.Error("Cannot update operator config map", zap.Error(err))
 		return reconcile.Result{RequeueAfter: time.Minute}, err
+	}
+
+	if cr.Spec.PgBackRest != nil {
+		masterPod, err := pr.helper.ResourceManager.GetPodsByLabel(MasterLabel)
+		if err != nil || len(masterPod.Items) == 0 {
+			pr.logger.Error("Can't get Patroni Leader for stanza upgrade execution", zap.Error(err))
+			return reconcile.Result{RequeueAfter: time.Minute}, err
+		}
+		masterPodName := masterPod.Items[0].Name
+		namespace := util.GetNameSpace()
+		backRestcontainer := "pgbackrest-sidecar"
+		backRestcommand := "pgbackrest stanza-upgrade"
+		pr.logger.Info("executing command to upgrade pgBackRest stanza")
+		stdout, stderr, err := pr.helper.ExecCmdOnPod(masterPodName, namespace, backRestcontainer, backRestcommand)
+		if err != nil {
+			fmt.Printf("Failed to execute stanza-upgrade command: %v\nStderr: %s\n", err, stderr)
+		} else {
+			fmt.Printf("stanza-upgrade command succeeded:\n%s\n", stdout)
+		}
 	}
 
 	if cr.Spec.Patroni != nil && cr.Spec.Patroni.IgnoreSlots {

--- a/pkg/helper/patroni_core_helper.go
+++ b/pkg/helper/patroni_core_helper.go
@@ -283,28 +283,33 @@ func UpdatePreloadLibraries(cr *qubershipv1.PatroniCore, preloadLibraries []stri
 	//helper.UpdatePostgresService()
 }
 
+// new method for executing commnad in patroni pod terminal
 func (ph *PatroniHelper) ExecCmdOnPatroniPod(podName string, namespace string, command string) (string, string, error) {
+	container := util.GetContainerNameForPatroniPod(podName)
+	return ph.ExecCmdOnPod(podName, namespace, container, command)
+}
+
+func (ph *PatroniHelper) ExecCmdOnPod(podName string, namespace string, container string, command string) (string, string, error) {
 	client := ph.kubeClientSet
-	logger.Debug(fmt.Sprintf("Executing shell command: %s  on pod %s", command, podName))
+	logger.Debug(fmt.Sprintf("Executing shell command: %s on pod %s, container %s", command, podName, container))
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		panic(err.Error())
+		return "", "", fmt.Errorf("error getting cluster config: %v", err)
 	}
 
 	execParams := &v1.PodExecOptions{
-		Command: []string{"/bin/sh", "-c", command},
-		Stdin:   false,
-		Stdout:  true,
-		Stderr:  true,
-		TTY:     true,
-	}
-
-	if strings.Contains(podName, "patroni") {
-		execParams.Container = util.GetContainerNameForPatroniPod(podName)
+		Command:   []string{"/bin/sh", "-c", command},
+		Container: container,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
 	}
 
 	buf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
+
 	request := client.CoreV1().RESTClient().
 		Post().
 		Namespace(namespace).
@@ -312,20 +317,67 @@ func (ph *PatroniHelper) ExecCmdOnPatroniPod(podName string, namespace string, c
 		Name(podName).
 		SubResource("exec").
 		VersionedParams(execParams, scheme.ParameterCodec)
+
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", request.URL())
 	if err != nil {
 		return "", "", fmt.Errorf("error creating SPDY executor: %v", err)
 	}
+
 	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
 		Stdout: buf,
 		Stderr: errBuf,
 	})
+
 	if err != nil {
-		logger.Error(fmt.Sprintf("Executing shell command: Error: \n%v\nerrBuf: %v", err, errBuf))
-		return "", "", fmt.Errorf("%w Failed executing command %s on %v/%v", err, command, namespace, podName)
+		return buf.String(), errBuf.String(), fmt.Errorf("error executing command: %v, stderr: %s", err, errBuf.String())
 	}
+
 	return buf.String(), errBuf.String(), nil
 }
+
+// func (ph *PatroniHelper) ExecCmdOnPatroniPod(podName string, namespace string, command string) (string, string, error) {
+// 	client := ph.kubeClientSet
+// 	logger.Debug(fmt.Sprintf("Executing shell command: %s  on pod %s", command, podName))
+// 	config, err := rest.InClusterConfig()
+// 	if err != nil {
+// 		panic(err.Error())
+// 	}
+
+// 	execParams := &v1.PodExecOptions{
+// 		Command: []string{"/bin/sh", "-c", command},
+// 		Stdin:   false,
+// 		Stdout:  true,
+// 		Stderr:  true,
+// 		TTY:     true,
+// 	}
+
+// 	if strings.Contains(podName, "patroni") {
+// 		execParams.Container = util.GetContainerNameForPatroniPod(podName)
+// 	}
+
+// 	buf := &bytes.Buffer{}
+// 	errBuf := &bytes.Buffer{}
+// 	request := client.CoreV1().RESTClient().
+// 		Post().
+// 		Namespace(namespace).
+// 		Resource("pods").
+// 		Name(podName).
+// 		SubResource("exec").
+// 		VersionedParams(execParams, scheme.ParameterCodec)
+// 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", request.URL())
+// 	if err != nil {
+// 		return "", "", fmt.Errorf("error creating SPDY executor: %v", err)
+// 	}
+// 	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+// 		Stdout: buf,
+// 		Stderr: errBuf,
+// 	})
+// 	if err != nil {
+// 		logger.Error(fmt.Sprintf("Executing shell command: Error: \n%v\nerrBuf: %v", err, errBuf))
+// 		return "", "", fmt.Errorf("%w Failed executing command %s on %v/%v", err, command, namespace, podName)
+// 	}
+// 	return buf.String(), errBuf.String(), nil
+// }
 
 func (ph *PatroniHelper) RevokeGrantOnPublicSchema(pgHost string) error {
 	const dbName = "template1"

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -445,6 +445,7 @@ func (u *Upgrade) ProceedUpgrade(cr *v1.PatroniCore, cluster *v1.PatroniClusterS
 	}
 
 	if cr.Spec.PgBackRest != nil {
+		logger.Info("executing code to upgrade pgBackRest stanza")
 		stdout, stderr, err := u.helper.ExecCmdOnPod(masterPodName, namespace, backRestcontainer, backRestcommand)
 		if err != nil {
 			fmt.Printf("Failed to execute stanza-upgrade command: %v\nStderr: %s\n", err, stderr)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -311,8 +311,6 @@ func (u *Upgrade) ProceedUpgrade(cr *v1.PatroniCore, cluster *v1.PatroniClusterS
 	}
 	masterPodName := masterPod.Items[0].Name
 	namespace := util.GetNameSpace()
-	backRestcontainer := "pgbackrest-sidecar" // The sidecar container for pgBackRest
-	backRestcommand := "pgbackrest stanza-upgrade"
 	command := "pg_dumpall -v -U postgres -w --file=/tmp/test_db_dumpall.custom --schema-only"
 	_, _, err = u.helper.ExecCmdOnPatroniPod(masterPodName, namespace, command)
 	if err != nil {
@@ -442,16 +440,6 @@ func (u *Upgrade) ProceedUpgrade(cr *v1.PatroniCore, cluster *v1.PatroniClusterS
 	//Upgrade complete, scaling up powa-ui deployment
 	if err := u.ScalePowaDeployment(1); err != nil {
 		return err
-	}
-
-	if cr.Spec.PgBackRest != nil {
-		logger.Info("executing code to upgrade pgBackRest stanza")
-		stdout, stderr, err := u.helper.ExecCmdOnPod(masterPodName, namespace, backRestcontainer, backRestcommand)
-		if err != nil {
-			fmt.Printf("Failed to execute stanza-upgrade command: %v\nStderr: %s\n", err, stderr)
-		} else {
-			fmt.Printf("stanza-upgrade command succeeded:\n%s\n", stdout)
-		}
 	}
 
 	if err := u.UpdateUpgradeToDone(); err != nil {


### PR DESCRIPTION
This fix is done to fix working of pgbackrest after major upgrade. In reconciliation cycle, we have added code which would be responsible to run command to upgrade pgbackrest stanza when pgbackrest and patroni specs are not null.