### PR TITLE
Set unique name for credential-saver job

### DIFF
--- a/charts/patroni-core/templates/hooks/creds-hook.yaml
+++ b/charts/patroni-core/templates/hooks/creds-hook.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "credentials-saver"
+  name: {{ printf "credentials-saver-%s" (lower (randAlphaNum 5)) }}
   labels:
 {{- if .Values.podLabels }}
 {{ .Values.podLabels | toYaml | nindent 4 }}

--- a/cmd/pgskipper-operator/main.go
+++ b/cmd/pgskipper-operator/main.go
@@ -21,6 +21,7 @@ import (
 	site "github.com/Netcracker/pgskipper-operator/pkg/disasterrecovery"
 	"github.com/Netcracker/pgskipper-operator/pkg/helper"
 	"github.com/Netcracker/pgskipper-operator/pkg/vault"
+	"github.com/Netcracker/qubership-credential-manager/pkg/hook"
 
 	"net/http"
 	"os"
@@ -150,6 +151,7 @@ func main() {
 		}
 	}()
 
+	_ = hook.ClearHooks()
 	setupLog.Info("Starting the Cmd.")
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
New name for credential job will be generated. Clean up logic for absolete jobs was added in the operator