### PR TITLE
feat: Enhance PgBackRest configuration with BackupFromStandby support

### DIFF
--- a/api/apps/v1/postgresservice_types.go
+++ b/api/apps/v1/postgresservice_types.go
@@ -233,13 +233,14 @@ type Tls struct {
 }
 
 type PgBackRest struct {
-	DockerImage  string         `json:"dockerImage,omitempty"`
-	RepoType     string         `json:"repoType,omitempty"`
-	RepoPath     string         `json:"repoPath,omitempty"`
-	DiffSchedule string         `json:"diffSchedule,omitempty"`
-	IncrSchedule string         `json:"incrSchedule,omitempty"`
-	S3           S3             `json:"s3,omitempty"`
-	Rwx          *types.Storage `json:"rwx,omitempty"`
+	DockerImage       string         `json:"dockerImage,omitempty"`
+	RepoType          string         `json:"repoType,omitempty"`
+	RepoPath          string         `json:"repoPath,omitempty"`
+	DiffSchedule      string         `json:"diffSchedule,omitempty"`
+	IncrSchedule      string         `json:"incrSchedule,omitempty"`
+	S3                S3             `json:"s3,omitempty"`
+	Rwx               *types.Storage `json:"rwx,omitempty"`
+	BackupFromStandby bool           `json:"backupFromStandby,omitempty"`
 }
 
 type S3 struct {

--- a/api/patroni/v1/patronicore_types.go
+++ b/api/patroni/v1/patronicore_types.go
@@ -202,17 +202,18 @@ type PatroniCoreStatus struct {
 }
 
 type PgBackRest struct {
-	DockerImage   string                   `json:"dockerImage,omitempty"`
-	RepoType      string                   `json:"repoType,omitempty"`
-	RepoPath      string                   `json:"repoPath,omitempty"`
-	DiffSchedule  string                   `json:"diffSchedule,omitempty"`
-	IncrSchedule  string                   `json:"incrSchedule,omitempty"`
-	S3            S3                       `json:"s3,omitempty"`
-	Rwx           *types.Storage           `json:"rwx,omitempty"`
-	Resources     *v1.ResourceRequirements `json:"resources,omitempty"`
-	FullRetention int                      `json:"fullRetention,omitempty"`
-	DiffRetention int                      `json:"diffRetention,omitempty"`
-	ConfigParams  []string                 `json:"configParams,omitempty"`
+	DockerImage       string                   `json:"dockerImage,omitempty"`
+	RepoType          string                   `json:"repoType,omitempty"`
+	RepoPath          string                   `json:"repoPath,omitempty"`
+	DiffSchedule      string                   `json:"diffSchedule,omitempty"`
+	IncrSchedule      string                   `json:"incrSchedule,omitempty"`
+	S3                S3                       `json:"s3,omitempty"`
+	Rwx               *types.Storage           `json:"rwx,omitempty"`
+	Resources         *v1.ResourceRequirements `json:"resources,omitempty"`
+	FullRetention     int                      `json:"fullRetention,omitempty"`
+	DiffRetention     int                      `json:"diffRetention,omitempty"`
+	BackupFromStandby bool                     `json:"backupFromStandby,omitempty"`
+	ConfigParams      []string                 `json:"configParams,omitempty"`
 }
 
 type S3 struct {

--- a/charts/patroni-core/templates/cr.yaml
+++ b/charts/patroni-core/templates/cr.yaml
@@ -195,6 +195,7 @@ spec:
     repoPath: {{ .Values.pgBackRest.repoPath | default "/var/lib/pgbackrest" }}
     diffSchedule: {{ .Values.pgBackRest.diffSchedule | default "0 0/1 * * *" }}
     incrSchedule: {{ .Values.pgBackRest.incrSchedule | default "0 0/1 * * *" }}
+    backupFromStandby: {{ .Values.pgBackRest.backupFromStandby | default false }}
   {{ if .Values.pgBackRest.rwx }}
     rwx:
 {{ toYaml .Values.pgBackRest.rwx | indent 6 }}

--- a/charts/patroni-services/templates/cr.yaml
+++ b/charts/patroni-services/templates/cr.yaml
@@ -403,6 +403,7 @@ spec:
     incrSchedule: {{ .Values.pgBackRest.incrSchedule | default "0 0/1 * * *" }}
     fullRetention: {{ .Values.pgBackRest.fullRetention | default 5 }}
     diffRetention: {{ .Values.pgBackRest.diffRetention | default 3 }}
+    backupFromStandby: {{ .Values.pgBackRest.backupFromStandby | default false }}
     configParams: {{ .Values.pgBackRest.configParams | default (list) | toJson }}
   {{ if .Values.pgBackRest.rwx }}
     rwx:

--- a/controllers/patroni_core_controller.go
+++ b/controllers/patroni_core_controller.go
@@ -196,7 +196,7 @@ func (pr *PatroniCoreReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	}
 
 	pr.logger.Info("Reconcile will be started...")
-	time.Sleep(60 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	if err := credentials.ProcessCreds(pr.helper.GetOwnerReferences()); err != nil {
 		return pr.handleReconcileError(maxReconcileAttempts,

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/operator-framework/operator-lib v0.15.0
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.27.0
+	golang.org/x/crypto v0.35.0
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.1
@@ -111,7 +112,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.33.0 // indirect

--- a/pkg/helper/patroni_core_helper.go
+++ b/pkg/helper/patroni_core_helper.go
@@ -430,16 +430,9 @@ func (ph *PatroniHelper) ClearStandbyClusterConfigurationConfigMap(patroniUrl st
 func (ph *PatroniHelper) getStandbyClusterConfigurationFromSiteManager() map[string]interface{} {
 	if cr, err := ph.GetPostgresServiceCR(); err == nil {
 		if coreCr, err := ph.GetPatroniCoreCR(); err == nil {
-
 			host := cr.Spec.SiteManager.ActiveClusterHost
 			port := cr.Spec.SiteManager.ActiveClusterPort
-			standbyClusterConfiguration := map[string]interface{}{
-				"host":                   host,
-				"port":                   port,
-				"primary_slot_name":      util.GetPatroniClusterName(coreCr.Spec.Patroni.ClusterName),
-				"create_replica_methods": []string{"basebackup"},
-			}
-			return standbyClusterConfiguration
+			return patroni.GetStandbyClusterConfigurationWithHost(coreCr, host, port)
 		}
 		return nil
 	}

--- a/pkg/helper/resource_management.go
+++ b/pkg/helper/resource_management.go
@@ -35,6 +35,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	k8sauth "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -426,7 +427,7 @@ func (rm *ResourceManager) CreateOrUpdateStatefulset(statefulSet *appsv1.Statefu
 			return err
 		}
 	} else {
-		if !reflect.DeepEqual(statefulSetBefore, statefulSet) {
+		if !equality.Semantic.DeepEqual(statefulSetBefore.Spec, statefulSet.Spec) {
 			logger.Info(fmt.Sprintf("Updating %s k8s StatefulSet", statefulSet.ObjectMeta.Name))
 			err = rm.kubeClient.Delete(context.TODO(), statefulSetBefore)
 			if err != nil {

--- a/pkg/reconciler/backup_daemon.go
+++ b/pkg/reconciler/backup_daemon.go
@@ -205,6 +205,13 @@ func (r *BackupDaemonReconciler) Reconcile() error {
 				break
 			}
 		}
+		if cr.Spec.PgBackRest.BackupFromStandby {
+			logger.Info("Set backup from standby parameter for backup-daemon")
+			envValue = append(envValue, corev1.EnvVar{
+				Name:  "BACKUP_FROM_STANDBY",
+				Value: "true",
+			})
+		}
 		backupDaemonDeployment.Spec.Template.Spec.Containers[0].Env = append(backupDaemonDeployment.Spec.Template.Spec.Containers[0].Env, envValue...)
 	}
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -480,7 +480,7 @@ func (u *Upgrade) getUpgradePod(patroniSpec *v1.Patroni, leaderName string, init
 					Name:            "pg-upgrade",
 					Image:           upgradeImage,
 					SecurityContext: opUtil.GetDefaultSecurityContext(),
-					ImagePullPolicy: "Always",
+					ImagePullPolicy: "IfNotPresent",
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							MountPath: "/var/lib/pgsql/data",
@@ -648,7 +648,7 @@ func (u *Upgrade) getUpgradeCheckPod(cr *v1.PatroniCore) *corev1.Pod {
 					Name:            "pg-upgrade-check",
 					Image:           patroniSpec.DockerImage,
 					SecurityContext: opUtil.GetDefaultSecurityContext(),
-					ImagePullPolicy: "Always",
+					ImagePullPolicy: "IfNotPresent",
 					Command:         []string{"sleep", "infinity"},
 					Resources: corev1.ResourceRequirements{
 						Requests: map[corev1.ResourceName]resource.Quantity{


### PR DESCRIPTION
- Added BackupFromStandby field to PgBackRest struct in API types.
- Updated Helm charts to include BackupFromStandby parameter in CRD templates.
- Modified Patroni reconciler to handle BackupFromStandby logic, including SSH key generation for standby backups.
- Adjusted deployment logic to create services for standby PgBackRest.
- Improved environment variable handling for backup daemon to support standby backups.
- Updated Go modules to include necessary dependencies.