### PR TITLE
feat: Enhance PgBackRest support for standby clusters

### DIFF
--- a/api/patroni/v1/patronicore_types.go
+++ b/api/patroni/v1/patronicore_types.go
@@ -210,6 +210,7 @@ type PgBackRest struct {
 	DiffSchedule      string                   `json:"diffSchedule,omitempty"`
 	IncrSchedule      string                   `json:"incrSchedule,omitempty"`
 	S3                S3                       `json:"s3,omitempty"`
+	DRS3              S3                       `json:"drS3,omitempty"`
 	Rwx               *types.Storage           `json:"rwx,omitempty"`
 	Resources         *v1.ResourceRequirements `json:"resources,omitempty"`
 	FullRetention     int                      `json:"fullRetention,omitempty"`

--- a/api/patroni/v1/zz_generated.deepcopy.go
+++ b/api/patroni/v1/zz_generated.deepcopy.go
@@ -459,6 +459,7 @@ func (in *PatroniCoreStatusCondition) DeepCopy() *PatroniCoreStatusCondition {
 func (in *PgBackRest) DeepCopyInto(out *PgBackRest) {
 	*out = *in
 	out.S3 = in.S3
+	out.DRS3 = in.DRS3
 	if in.Rwx != nil {
 		in, out := &in.Rwx, &out.Rwx
 		*out = new(apiv1.Storage)

--- a/charts/patroni-core/templates/cr.yaml
+++ b/charts/patroni-core/templates/cr.yaml
@@ -208,6 +208,10 @@ spec:
     s3:
 {{ toYaml .Values.pgBackRest.s3 | indent 6 }}
   {{ end }}
+{{ if .Values.pgBackRest.drS3 }}
+    drS3:
+{{ toYaml .Values.pgBackRest.drS3 | indent 6 }}
+{{ end }}
 {{- if .Values.pgBackRest.resources }}
     resources:
 {{ toYaml .Values.pgBackRest.resources | indent 6 }}

--- a/pkg/disasterrecovery/server.go
+++ b/pkg/disasterrecovery/server.go
@@ -47,16 +47,28 @@ func InitDRManager() {
 	helper := k8sHelper.GetHelper()
 	patroniHelper := k8sHelper.GetPatroniHelper()
 	cloudSqlCm := getCloudSqlCm(helper)
-	cr, _ := helper.GetPostgresServiceCR()
-	err := helper.AddNameAndUID(cr.Name, cr.UID, cr.Kind)
+
+	cr, err := helper.GetPostgresServiceCR()
 	if err != nil {
 		log.Error("Can not init Site Manager", zap.Error(err))
 	}
-	err = patroniHelper.AddNameAndUID(cr.Name, cr.UID, cr.Kind)
+	err = helper.AddNameAndUID(cr.Name, cr.UID, cr.Kind)
+	if err != nil {
+		log.Error("Can not init Site Manager", zap.Error(err))
+		panic(err)
+	}
+
+	coreCR, err := patroniHelper.GetPatroniCoreCR()
+	if err != nil {
+		log.Error("Can not init Site Manager", zap.Error(err))
+		panic(err)
+	}
+	err = patroniHelper.AddNameAndUID(coreCR.Name, coreCR.UID, coreCR.Kind)
 	if err != nil {
 		log.Error("Can not init Site Manager", zap.Error(err))
 	}
-	patroniClusterSettings := util.GetPatroniClusterSettings(cr.Spec.Patroni.ClusterName)
+
+	patroniClusterSettings := util.GetPatroniClusterSettings(coreCR.Spec.Patroni.ClusterName)
 	if cloudSqlCm != nil {
 		pgManager = newCloudSQLDRManager(helper, cloudSqlCm)
 	} else {

--- a/pkg/patroni/patroni.go
+++ b/pkg/patroni/patroni.go
@@ -50,15 +50,9 @@ type Members map[string]interface{}
 func SetWalArchiving(spec qubershipv1.PatroniServicesSpec, patroniUrl string) error {
 	postgreSQLParams := map[string]interface{}{}
 	recoveryParams := map[string]string{}
-	patroniParams := map[string]interface{}{}
 	if spec.PgBackRest != nil {
-		logger.Info("pgBackRest feature is turned On, settings archive_command and restore_command for pgBackRest option")
-		postgreSQLParams["archive_mode"] = constants.ArchiveModeOn
-		postgreSQLParams["archive_command"] = constants.PgBackRestArchiveCommand
-
-		recoveryParams["restore_command"] = constants.PgBackRestRestoreCommand
-		postgreSQLParams["create_replica_methods"] = []string{"pgbackrest"}
-		recoveryParams["recovery_target_timeline"] = "latest"
+		logger.Info("pgBackRest feature is turned On, skipping wal archiving settings")
+		return nil
 	} else if spec.BackupDaemon.WalArchiving {
 		logger.Info("WAL Archiving is turned On, settings archive_command and restore_command")
 		postgreSQLParams["archive_mode"] = constants.ArchiveModeOn
@@ -71,20 +65,33 @@ func SetWalArchiving(spec qubershipv1.PatroniServicesSpec, patroniUrl string) er
 		recoveryParams["restore_command"] = ""
 	}
 
+	return setArchivingConfiguration(postgreSQLParams, recoveryParams, patroniUrl)
+}
+
+func SetWalArchivingForPgBackRest(cr *patroniv1.PatroniCore, patroniUrl string) error {
+	postgreSQLParams := map[string]interface{}{}
+	recoveryParams := map[string]string{}
+	if cr.Spec.PgBackRest != nil {
+		logger.Info("pgBackRest feature is turned On, settings archive_command and restore_command for pgBackRest option")
+		postgreSQLParams["archive_mode"] = constants.ArchiveModeOn
+		postgreSQLParams["archive_command"] = constants.PgBackRestArchiveCommand
+
+		recoveryParams["restore_command"] = GetCommandForPgbackrest(cr, constants.PgBackRestRestoreCommand)
+	}
+
+	return setArchivingConfiguration(postgreSQLParams, recoveryParams, patroniUrl)
+}
+
+func setArchivingConfiguration(postgreSQLParams map[string]interface{}, recoveryParams map[string]string, patroniUrl string) error {
+	patroniParams := map[string]interface{}{}
+
 	patroniParams["parameters"] = postgreSQLParams
 	patroniParams["recovery_conf"] = recoveryParams
 
 	patchData := map[string]interface{}{
 		"postgresql": patroniParams,
 	}
-	if spec.PgBackRest != nil {
-		patchData = map[string]interface{}{
-			"postgresql": map[string]interface{}{
-				"parameters":    postgreSQLParams,
-				"recovery_conf": recoveryParams,
-			},
-		}
-	}
+
 	// send update to patroni
 	if err := UpdatePatroniConfig(patchData, patroniUrl); err != nil {
 		logger.Error("Failed to patch postgresql params via patroni", zap.Error(err))
@@ -303,10 +310,19 @@ func GetStandbyClusterConfigurationWithHost(cr *patroniv1.PatroniCore, host stri
 
 	if cr.Spec.PgBackRest != nil {
 		standbyClusterConfiguration["create_replica_methods"] = []string{"pgbackrest", "basebackup"}
-		standbyClusterConfiguration["restore_command"] = "pgbackrest --stanza=patroni --delta --log-level-file=detail restore"
+		standbyClusterConfiguration["restore_command"] = GetCommandForPgbackrest(cr, constants.PgBackRestRestoreCommand)
 	}
 
 	return standbyClusterConfiguration
+}
+
+func GetCommandForPgbackrest(cr *patroniv1.PatroniCore, command string) string {
+	if IsStandbyClusterConfigurationExist(cr) {
+		if cr.Spec.PgBackRest.DRS3.Bucket != "" {
+			return fmt.Sprintf(`%s --repo=2`, command)
+		}
+	}
+	return command
 }
 
 func updateStandbyClusterSettings(configMap *corev1.ConfigMap, settings interface{}, configMapKey string) *corev1.ConfigMap {


### PR DESCRIPTION
- Added DRS3 configuration to PgBackRest struct for dual repository support.
- Updated reconciliation logic to handle stanza creation for standby clusters with DRS3.
- Modified command execution to differentiate between stanza upgrade and creation based on DRS3 presence.
- Adjusted configuration management to include DRS3 settings in the pgBackRest ConfigMap.