### PR TITLE
PSUPCLCAP-1648 fix params defaults

### DIFF
--- a/charts/patroni-core/templates/cr.yaml
+++ b/charts/patroni-core/templates/cr.yaml
@@ -67,10 +67,14 @@ spec:
     podLabels:
       {{ include "kubernetes.labels" . | nindent 6 }}
     {{- end }}
+    {{ if .Values.patroni.podAnnotations }}
     podAnnotations:
       {{- toYaml .Values.patroni.podAnnotations | nindent 6 }}
+    {{ end }}
+    {{ if .Values.patroni.configMapAnnotations }}
     configMapAnnotations:
       {{- toYaml .Values.patroni.configMapAnnotations | nindent 6 }}
+    {{ end }}
     replicas: {{ ( include "postgres.replicasCount" . ) }}
     image: {{ template "find_image" (dict "deployName" "pg_patroni" "SERVICE_NAME" "pg_patroni" "vals" .Values "default" .Values.patroni.dockerImage) }}
     patroniParams:

--- a/pkg/deployment/patroni.go
+++ b/pkg/deployment/patroni.go
@@ -329,8 +329,10 @@ func NewPatroniStatefulset(cr *patroniv1.PatroniCore, deploymentIdx int, cluster
 	}
 	stSet.Spec.Template.ObjectMeta.Annotations["argocd.argoproj.io/ignore-resource-updates"] = "true"
 
-	for k, v := range patroniSpec.PodAnnotations {
-		stSet.Spec.Template.ObjectMeta.Annotations[k] = v
+	if patroniSpec.PodAnnotations != nil {
+		for k, v := range patroniSpec.PodAnnotations {
+			stSet.Spec.Template.ObjectMeta.Annotations[k] = v
+		}
 	}
 
 	// TLS Section

--- a/pkg/reconciler/patroni.go
+++ b/pkg/reconciler/patroni.go
@@ -406,8 +406,10 @@ func (r *PatroniReconciler) Reconcile() error {
 			cm.Annotations = make(map[string]string)
 		}
 		cm.Annotations["argocd.argoproj.io/ignore-resource-updates"] = "true"
-		for k, v := range cr.Spec.Patroni.ConfigMapAnnotations {
-			cm.Annotations[k] = v
+		if patroniSpec.ConfigMapAnnotations != nil {
+			for k, v := range patroniSpec.ConfigMapAnnotations {
+				cm.Annotations[k] = v
+			}
 		}
 		if _, err := r.helper.ResourceManager.CreateOrUpdateConfigMap(cm); err != nil {
 			logger.Error("failed to annotate Patroni ConfigMap", zap.Error(err))


### PR DESCRIPTION
Adding fields podAnnotations and configMapAnnotations to CR only if they are not empty.
ArgoCD have a problem with empty params.