### PR TITLE
feat: allow customization for imagePullPolicy

### DIFF
--- a/api/patroni/v1/patronicore_types.go
+++ b/api/patroni/v1/patronicore_types.go
@@ -84,6 +84,7 @@ type Patroni struct {
 	Resources                    *v1.ResourceRequirements `json:"resources,omitempty"`
 	Replicas                     int                      `json:"replicas,omitempty"`
 	DockerImage                  string                   `json:"image,omitempty"`
+	DockerImagePullPolicy        v1.PullPolicy            `json:"imagePullPolicy,omitempty"`
 	Storage                      *types.Storage           `json:"storage,omitempty"`
 	Affinity                     v1.Affinity              `json:"affinity,omitempty"`
 	PostgreSQLParams             []string                 `json:"postgreSQLParams,omitempty"`

--- a/charts/patroni-core/templates/deployment.yaml
+++ b/charts/patroni-core/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: patroni-core-operator
           image: {{ template "find_image" (dict "deployName" "patroni_core" "SERVICE_NAME" "patroni-core" "vals" .Values "default" .Values.operator.image) }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ default "Always" .Values.operator.imagePullPolicy }}
           {{ if .Values.operator.priorityClassName }}
           priorityClassName: {{ .Values.operator.priorityClassName }}
           {{ end }}

--- a/charts/patroni-core/templates/hooks/creds-hook.yaml
+++ b/charts/patroni-core/templates/hooks/creds-hook.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: credentials-saver
         image: {{ template "find_image" (dict "deployName" "postgres_operator_init" "SERVICE_NAME" "postgres_operator_init" "vals" .Values "default" .Values.operatorInit.image) }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ default "Always" .Values.operatorInit.imagePullPolicy }}
         env:
           - name: IS_HOOK
             value: "True"

--- a/charts/patroni-core/values.yaml
+++ b/charts/patroni-core/values.yaml
@@ -29,6 +29,7 @@ serviceAccount:
 
 operatorInit:
   image: ghcr.io/netcracker/qubership-credential-manager:main
+  imagePullPolicy: Always
   resources:
     limits:
       cpu: 50m
@@ -41,6 +42,7 @@ operatorInit:
 operator:
   # Docker Image that will be used to Postgres Operator deployment
   image: ghcr.io/netcracker/pgskipper-operator:main
+  imagePullPolicy: Always
   podLabels: {}
   securityContext: {}
   waitTimeout: 10

--- a/charts/patroni-services/templates/dbaas/dbaas-adapter-deployment.yaml
+++ b/charts/patroni-services/templates/dbaas/dbaas-adapter-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- end }}
         - name: init-dbaas-postgres-adapter
           image: {{ template "find_image" (dict "deployName" "postgresql_dbaas_adapter" "SERVICE_NAME" "postgresql_dbaas_adapter" "vals" .Values "default" .Values.dbaas.dockerImage) }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ default "Always" .Values.dbaas.imagePullPolicy }}
           {{- if or .Values.vaultRegistration.enabled .Values.vaultRegistration.dbEngine.enabled }}
           command:
             - /vault/vault-env
@@ -144,6 +144,7 @@ spec:
       containers:
         - name: dbaas-postgres-adapter
           image: {{ template "find_image" (dict "deployName" "postgresql_dbaas_adapter" "SERVICE_NAME" "postgresql_dbaas_adapter" "vals" .Values "default" .Values.dbaas.dockerImage) }}
+          imagePullPolicy: {{ default "Always" .Values.dbaas.imagePullPolicy }}
           {{- if or .Values.vaultRegistration.enabled .Values.vaultRegistration.dbEngine.enabled }}
           command:
             - /vault/vault-env
@@ -269,7 +270,6 @@ spec:
             failureThreshold: 10
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-          imagePullPolicy: IfNotPresent
       {{- if .Values.privateRegistry.enabled }}
       imagePullSecrets:
         {{- range $i, $v := .Values.privateRegistry.secrets }}

--- a/charts/patroni-services/templates/deployment.yaml
+++ b/charts/patroni-services/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: patroni-services
           image: {{ template "find_image" (dict "deployName" "postgres_operator" "SERVICE_NAME" "patroni-services" "vals" .Values "default" .Values.operator.image) }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ default "Always" .Values.operator.imagePullPolicy }}
           {{ if .Values.operator.priorityClassName }}
           priorityClassName: {{ .Values.operator.priorityClassName }}
           {{ end }}

--- a/charts/patroni-services/values.yaml
+++ b/charts/patroni-services/values.yaml
@@ -34,6 +34,7 @@ operatorInit:
 operator:
   # Docker Image that will be used to Postgres Operator deployment
   image: ghcr.io/netcracker/pgskipper-operator:main
+  imagePullPolicy: Always
   podLabels: {}
   securityContext: {}
   waitTimeout: 10
@@ -284,6 +285,7 @@ dbaas:
   multiUsers: true
   # Docker Image that will be used for PostgreSQL DBaaS Adapter container
   dockerImage: ghcr.io/netcracker/pgskipper-dbaas-adapter:main
+  imagePullPolicy: Always
   podLabels: {}
   securityContext: {}
   # PostgreSQL cluster entry point.

--- a/pkg/deployment/patroni.go
+++ b/pkg/deployment/patroni.go
@@ -177,6 +177,7 @@ func NewPatroniStatefulset(cr *patroniv1.PatroniCore, deploymentIdx int, cluster
 						{
 							Name:            statefulsetName,
 							Image:           dockerImage,
+							ImagePullPolicy: patroniSpec.DockerImagePullPolicy,
 							SecurityContext: util.GetDefaultSecurityContext(),
 							Command:         []string{},
 							Args:            []string{},
@@ -299,8 +300,7 @@ func NewPatroniStatefulset(cr *patroniv1.PatroniCore, deploymentIdx int, cluster
 									Name:      "postgresql-config",
 								},
 							},
-							Resources:       *patroniSpec.Resources,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: *patroniSpec.Resources,
 						},
 					},
 					RestartPolicy:                 corev1.RestartPolicyAlways,

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -498,7 +498,7 @@ func (u *Upgrade) getUpgradePod(patroniSpec *v1.Patroni, leaderName string, init
 					Name:            "pg-upgrade",
 					Image:           upgradeImage,
 					SecurityContext: opUtil.GetDefaultSecurityContext(),
-					ImagePullPolicy: "IfNotPresent",
+					ImagePullPolicy: patroniSpec.DockerImagePullPolicy,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							MountPath: "/var/lib/pgsql/data",
@@ -665,8 +665,8 @@ func (u *Upgrade) getUpgradeCheckPod(cr *v1.PatroniCore) *corev1.Pod {
 				{
 					Name:            "pg-upgrade-check",
 					Image:           patroniSpec.DockerImage,
+					ImagePullPolicy: patroniSpec.DockerImagePullPolicy,
 					SecurityContext: opUtil.GetDefaultSecurityContext(),
-					ImagePullPolicy: "IfNotPresent",
 					Command:         []string{"sleep", "infinity"},
 					Resources: corev1.ResourceRequirements{
 						Requests: map[corev1.ResourceName]resource.Quantity{


### PR DESCRIPTION
Previously, imagePullPolicy was hard-coded, which makes it hard to test the operator locally without pushing the images to registries.