### PR TITLE
Add Spring Boot sample application for testing failover scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Postgres-Operator provides PostgreSQL as a service on Kubernetes and OpenShift.
 * * `./charts/patroni-services` - directory with HELM chart for Postgres Services.
 * `./pkg` - directory with operator source code, which is used for running Postgres Operator.
 * `./tests` - directory with robot test source code, `Dockerfile`.
+* * `./tests/examples` - example projects demonstrating various use cases.
 
 ## How to start
 
@@ -24,6 +25,11 @@ There are no well-defined rules for troubleshooting, as each task is unique, but
 
 * Deploy parameters.
 * Logs from all Postgres Service pods: operator, postgres db and others.
+
+## Examples
+
+* **[Spring Boot Failover Testing](tests/examples/spring-boot-failover-test/)** - Test PostgreSQL failover behavior with Spring Boot applications
+* [More Examples](tests/examples/) - Additional example projects
 
 ## Useful links
 

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -813,7 +813,7 @@ For more information on how to do the Major Upgrade of PostgreSQL, please, follo
 ```yaml
     pgbouncer:
       listen_port: '6432'
-      listen_addr: '0.0.0.0'
+      listen_addr: '*'
       auth_type: 'md5'
       auth_file: '/etc/pgbouncer/userlist.txt'
       auth_user: 'pgbouncer'

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -1,0 +1,173 @@
+# pgskipper-operator Helmfile Configuration
+#
+# This helmfile manages the deployment of pgskipper-operator components:
+# - Patroni-Core Operator (PostgreSQL core functionality)
+# - Patroni-Services Operator (PostgreSQL services)
+#
+# Usage:
+#   helmfile sync                      - Deploy with official images
+#   helmfile -e orbstack sync          - Deploy to OrbStack
+#   helmfile -e rancher sync           - Deploy to Rancher Desktop
+#   helmfile -e k3d-v4only sync        - Deploy to k3d with IPv4 only
+#   helmfile destroy                   - Uninstall releases (see cleanup note below)
+#
+# Environment Variables (optional):
+#   USE_LOCAL_IMAGES=true              - Build and use local operator images
+#   PGSKIPPER_IMAGE=<image>            - Override operator image (default: ghcr.io/netcracker/pgskipper-operator)
+#   PGSKIPPER_TAG=<tag>                - Override operator tag (default: main)
+#   NAMESPACE=<namespace>              - Target namespace (default: postgres)
+#
+# Examples:
+#   USE_LOCAL_IMAGES=true helmfile -e orbstack sync  - Build local images for OrbStack
+#   PGSKIPPER_TAG=v1.2.3 helmfile sync               - Use specific version from ghcr.io
+#
+# Cleanup after destroy:
+#   After running `helmfile destroy`, some operator-created resources may remain.
+#   To fully clean up, run:
+#     kubectl delete pvc,service,configmap --all -n postgres --ignore-not-found
+#   Or delete the entire namespace:
+#     kubectl delete namespace postgres
+
+helmDefaults:
+  wait: false
+  timeout: 600
+  createNamespace: true
+  cleanupOnFail: true
+
+environments:
+  default:
+    values:
+      - environments/default.yaml
+  k3d-v4only:
+    values:
+      - environments/k3d-v4only.yaml
+  orbstack:
+    values:
+      - environments/orbstack.yaml
+  rancher:
+    values:
+      - environments/rancher.yaml
+
+---
+
+{{ $namespace := env "NAMESPACE" | default "postgres" }}
+
+{{/* Image configuration via environment variables */}}
+{{ $useLocalImages := env "USE_LOCAL_IMAGES" | default "false" }}
+
+{{ $pgskipperImage := "" }}
+{{ $pgskipperTag := "" }}
+{{ $pullPolicy := "" }}
+
+{{ if eq $useLocalImages "true" }}
+  {{ $pgskipperImage = "pgskipper-operator" }}
+  {{ $pgskipperTag = "local" }}
+  {{ $pullPolicy = "Never" }}
+{{ else }}
+  {{ $pgskipperImage = env "PGSKIPPER_IMAGE" | default "ghcr.io/netcracker/pgskipper-operator" }}
+  {{ $pgskipperTag = env "PGSKIPPER_TAG" | default "main" }}
+  {{ $pullPolicy = "IfNotPresent" }}
+{{ end }}
+
+releases:
+  #############################################################################
+  # Patroni-Core Operator
+  # Manages PostgreSQL core functionality and CRDs
+  #############################################################################
+  - name: patroni-core
+    namespace: {{ $namespace }}
+    chart: ./operator/charts/patroni-core
+    labels:
+      component: postgres-operator
+      type: core
+    values:
+      - ./tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-simple.yaml
+      - operator:
+          image: {{ $pgskipperImage }}:{{ $pgskipperTag }}
+          imagePullPolicy: {{ $pullPolicy }}
+    hooks:
+      # Build custom operator images if requested
+      - events: ["presync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            if [ "{{ $useLocalImages }}" != "true" ]; then
+              echo "Using official pgskipper-operator images: {{ $pgskipperImage }}:{{ $pgskipperTag }}"
+            else
+              echo "Building local pgskipper-operator images..."
+
+              # Switch to configured Docker context (for local k8s like OrbStack/Rancher)
+              DOCKER_CONTEXT="{{ .Values.dockerContext | default "default" }}"
+              CURRENT_CONTEXT=$(docker context show)
+              echo "Current Docker context: $CURRENT_CONTEXT"
+              echo "Target Docker context: $DOCKER_CONTEXT"
+
+              if [ "$CURRENT_CONTEXT" != "$DOCKER_CONTEXT" ]; then
+                echo "Switching to $DOCKER_CONTEXT context..."
+                docker context use "$DOCKER_CONTEXT"
+              fi
+
+              TAG_ENV="{{ $pgskipperTag }}" DOCKER_NAMES="{{ $pgskipperImage }}:{{ $pgskipperTag }}" make docker-build
+
+              echo "✓ Local operator images built successfully: {{ $pgskipperImage }}:{{ $pgskipperTag }}"
+            fi
+      # Validate storage before deployment
+      - events: ["presync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            cd tests/examples/spring-boot-failover-test
+            ./scripts/configure-storage.sh --auto
+      # Wait for operator to be ready
+      - events: ["postsync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            echo "Waiting for Patroni-Core Operator to be ready..."
+            kubectl wait --for=condition=available --timeout=300s \
+              deployment -l name=patroni-core-operator -n {{ $namespace }} 2>/dev/null || true
+
+  #############################################################################
+  # Patroni-Services Operator
+  # Manages PostgreSQL services and high availability
+  #############################################################################
+  - name: patroni-services
+    namespace: {{ $namespace }}
+    chart: ./operator/charts/patroni-services
+    labels:
+      component: postgres-operator
+      type: services
+    values:
+      - ./tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-simple.yaml
+      - operator:
+          image: {{ $pgskipperImage }}:{{ $pgskipperTag }}
+          imagePullPolicy: {{ $pullPolicy }}
+    hooks:
+      # Wait for PostgreSQL cluster to be ready
+      - events: ["postsync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            echo "Waiting for PostgreSQL cluster to initialize..."
+            sleep 30
+
+            echo "Waiting for primary PostgreSQL pod..."
+            timeout 600 bash -c 'until kubectl get pods -n {{ $namespace }} --selector=pgtype=master 2>/dev/null | grep -q Running; do sleep 5; done' || true
+
+            echo "Waiting for all PostgreSQL pods to be ready..."
+            kubectl wait --for=condition=ready --timeout=600s \
+              pods -l app=postgres -n {{ $namespace }} 2>/dev/null || true
+
+            echo "PostgreSQL cluster is ready!"

--- a/operator/build/configs/patroni.config.yaml
+++ b/operator/build/configs/patroni.config.yaml
@@ -51,7 +51,7 @@ kubernetes:
     app: ${PATRONI_CLUSTER_NAME}
   role_label: pgtype
   scope_label: app
-  pod_ip: ${LISTEN_ADDR}
+  # pod_ip is omitted so Patroni auto-discovers it from pod.status.pod_ip
 postgresql:
   authentication:
     replication:
@@ -67,15 +67,15 @@ postgresql:
     on_role_change: /setup_endpoint_callback.py
     on_start: /setup_endpoint_callback.py
     on_stop: /setup_endpoint_callback.py
-  connect_address: ${LISTEN_ADDR}:5432
+  connect_address: ${POD_DNS_NAME}:5432
   data_dir: /var/lib/pgsql/data/postgresql_${NODE_NAME}
-  listen: '0.0.0.0, ::0:5432'
+  listen: '*:5432'
   parameters:
     unix_socket_directories: /var/run/postgresql, /tmp
   pgpass: /tmp/pgpass0
 restapi:
-  connect_address: ${LISTEN_ADDR}:8008
-  listen: ${LISTEN_ADDR}:8008
+  connect_address: ${POD_DNS_NAME}:8008
+  listen: '*:8008'
 tags:
   clonefrom: false
   nofailover: ${DR_MODE}

--- a/operator/charts/patroni-services/values.yaml
+++ b/operator/charts/patroni-services/values.yaml
@@ -415,7 +415,7 @@ connectionPooler:
       '*': "host=pg-patroni-direct port=5432"
     pgbouncer:
       listen_port: '6432'
-      listen_addr: '0.0.0.0'
+      listen_addr: '*'
       auth_type: 'md5'
       auth_file: '/etc/pgbouncer/userlist.txt'
       auth_user: 'pgbouncer'

--- a/operator/pkg/deployment/patroni.go
+++ b/operator/pkg/deployment/patroni.go
@@ -212,6 +212,31 @@ func NewPatroniStatefulset(cr *patroniv1.PatroniCore, deploymentIdx int, cluster
 									},
 								},
 								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.name",
+										},
+									},
+								},
+								{
+									Name:  "HEADLESS_SERVICE",
+									Value: fmt.Sprintf("patroni-%s-headless", clusterName),
+								},
+								{
+									Name:  "POD_DNS_NAME",
+									Value: "$(POD_NAME).$(HEADLESS_SERVICE).$(POD_NAMESPACE).svc",
+								},
+								{
+									Name: "PG_RESOURCES_LIMIT_MEM",
+									ValueFrom: &corev1.EnvVarSource{
+										ResourceFieldRef: &corev1.ResourceFieldSelector{
+											Resource: "limits.memory",
+										},
+									},
+								},
+								{
 									Name:  "PATRONI_CLUSTER_NAME",
 									Value: clusterName,
 								},
@@ -262,7 +287,7 @@ func NewPatroniStatefulset(cr *patroniv1.PatroniCore, deploymentIdx int, cluster
 					DNSPolicy:                     corev1.DNSClusterFirst,
 				},
 			},
-			ServiceName:                          "backrest-headless",
+			ServiceName:                          fmt.Sprintf("patroni-%s-headless", clusterName),
 			PodManagementPolicy:                  appsv1.OrderedReadyPodManagement,
 			UpdateStrategy:                       appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
 			RevisionHistoryLimit:                 ptr.To[int32](10),

--- a/operator/pkg/deployment/pgbackrest.go
+++ b/operator/pkg/deployment/pgbackrest.go
@@ -183,6 +183,30 @@ func GetBackrestHeadless() *corev1.Service {
 	}
 }
 
+func GetPatroniHeadless(clusterName string) *corev1.Service {
+	labels := map[string]string{"app": clusterName}
+	ports := []corev1.ServicePort{
+		{Name: "postgresql", Port: 5432},
+		{Name: "patroni-api", Port: 8008},
+	}
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("patroni-%s-headless", clusterName),
+			Namespace: util.GetNameSpace(),
+		},
+
+		Spec: corev1.ServiceSpec{
+			Selector:  labels,
+			Ports:     ports,
+			ClusterIP: "None",
+		},
+	}
+}
+
 func getPgBackRestSettings(pgBackrestSpec *v1.PgBackRest, isStandby bool) string {
 	var listSettings []string
 	listSettings = append(listSettings, "[global]")

--- a/operator/pkg/patroni/patroni.go
+++ b/operator/pkg/patroni/patroni.go
@@ -142,15 +142,17 @@ func UpdatePgbackRestSettings(configMap *corev1.ConfigMap, settings interface{},
 	return configMap, nil
 }
 
-func AddStandbyClusterSettings(cr *patroniv1.PatroniCore, configMap *corev1.ConfigMap, configMapKey string) {
+func AddStandbyClusterSettings(cr *patroniv1.PatroniCore, configMap *corev1.ConfigMap, configMapKey string) error {
 	logger.Info("Apply standby cluster configuration in patroni template config map")
 	standbyClusterConfiguration := getStandbyClusterConfiguration(cr)
-	updateStandbyClusterSettings(configMap, standbyClusterConfiguration, configMapKey)
+	_, err := updateStandbyClusterSettings(configMap, standbyClusterConfiguration, configMapKey)
+	return err
 }
 
-func DeleteStandbyClusterSettings(configMap *corev1.ConfigMap, configMapKey string) {
+func DeleteStandbyClusterSettings(configMap *corev1.ConfigMap, configMapKey string) error {
 	logger.Info("Delete standby cluster configuration in patroni template config map")
-	updateStandbyClusterSettings(configMap, "", configMapKey)
+	_, err := updateStandbyClusterSettings(configMap, "", configMapKey)
+	return err
 }
 
 func ClearStandbyClusterConfigurationConfigMap(patroniUrl string) error {
@@ -330,20 +332,41 @@ func GetCommandForPgbackrest(cr *patroniv1.PatroniCore, command string) string {
 	return command
 }
 
-func updateStandbyClusterSettings(configMap *corev1.ConfigMap, settings interface{}, configMapKey string) *corev1.ConfigMap {
+func updateStandbyClusterSettings(configMap *corev1.ConfigMap, settings interface{}, configMapKey string) (*corev1.ConfigMap, error) {
 
 	var config map[string]interface{}
 	err := yaml.Unmarshal([]byte(configMap.Data[configMapKey]), &config)
 	if err != nil {
 		logger.Error("Could not unmarshal patroni config map", zap.Error(err))
+		return configMap, fmt.Errorf("could not unmarshal patroni config map: %w", err)
 	}
-	config["bootstrap"].(map[interface{}]interface{})["dcs"].(map[interface{}]interface{})["standby_cluster"] = settings
+
+	if config == nil {
+		logger.Error("Config map is nil after unmarshal")
+		return configMap, fmt.Errorf("config map is nil after unmarshal")
+	}
+
+	bootstrap, ok := config["bootstrap"].(map[interface{}]interface{})
+	if !ok || bootstrap == nil {
+		logger.Error("Config map missing 'bootstrap' section or wrong type")
+		return configMap, fmt.Errorf("config map missing 'bootstrap' section or wrong type")
+	}
+
+	dcs, ok := bootstrap["dcs"].(map[interface{}]interface{})
+	if !ok || dcs == nil {
+		logger.Error("Config map missing 'bootstrap.dcs' section or wrong type")
+		return configMap, fmt.Errorf("config map missing 'bootstrap.dcs' section or wrong type")
+	}
+
+	dcs["standby_cluster"] = settings
+
 	result, err := yaml.Marshal(config)
 	if err != nil {
 		logger.Error("Could not marshal patroni config map", zap.Error(err))
+		return configMap, fmt.Errorf("could not marshal patroni config map: %w", err)
 	}
 	configMap.Data[configMapKey] = string(result)
-	return configMap
+	return configMap, nil
 }
 
 func UpdatePostgreSQLParams(patroni *patroniv1.Patroni, patroniUrl string) error {

--- a/operator/pkg/reconciler/patroni.go
+++ b/operator/pkg/reconciler/patroni.go
@@ -456,6 +456,14 @@ func (r *PatroniReconciler) processPatroniServices(cr *v1.PatroniCore, patroniSp
 			}
 		}
 	}
+
+	// Create patroni headless service for DNS-based pod discovery
+	patroniHeadless := deployment.GetPatroniHeadless(r.cluster.ClusterName)
+	if err := r.helper.ResourceManager.CreateOrUpdateService(patroniHeadless); err != nil {
+		logger.Error(fmt.Sprintf("Cannot create service %s", patroniHeadless.Name), zap.Error(err))
+		return err
+	}
+
 	return nil
 }
 

--- a/operator/pkg/reconciler/patroni.go
+++ b/operator/pkg/reconciler/patroni.go
@@ -90,9 +90,13 @@ func (r *PatroniReconciler) Reconcile() error {
 	}
 
 	if isStandbyClusterPresent {
-		patroni.AddStandbyClusterSettings(cr, patroniConfigMap, r.cluster.ConfigMapKey)
+		if err := patroni.AddStandbyClusterSettings(cr, patroniConfigMap, r.cluster.ConfigMapKey); err != nil {
+			return err
+		}
 	} else {
-		patroni.DeleteStandbyClusterSettings(patroniConfigMap, r.cluster.ConfigMapKey)
+		if err := patroni.DeleteStandbyClusterSettings(patroniConfigMap, r.cluster.ConfigMapKey); err != nil {
+			return err
+		}
 	}
 	if (patroniSpec.Dcs.Type == "etcd") || (patroniSpec.Dcs.Type == "etcd3") {
 		patroni.AddEtcdSettings(cr, patroniConfigMap, r.cluster.ConfigMapKey)

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -1,0 +1,48 @@
+# pgskipper-operator Examples
+
+This directory contains example projects demonstrating various use cases for pgskipper-operator.
+
+## Available Examples
+
+### [Spring Boot Failover Testing](spring-boot-failover-test/)
+
+A comprehensive testing environment to reproduce and analyze PostgreSQL failover behavior with Spring Boot applications using HikariCP connection pooling.
+
+**Features:**
+- PostgreSQL HA cluster with automatic failover
+- Spring Boot application with connection monitoring
+- Failover testing scripts
+- Detailed metrics and monitoring
+- HikariCP connection pool optimization
+
+**Use Cases:**
+- Testing application behavior during database failover
+- Validating connection pool configurations
+- Analyzing reconnection patterns and timing
+- Developing failover-resilient applications
+
+**Quick Start:**
+```bash
+cd spring-boot-failover-test
+helmfile sync
+```
+
+See the [full documentation](spring-boot-failover-test/README.md) for detailed instructions.
+
+---
+
+## Contributing Examples
+
+If you have an example demonstrating a specific use case for pgskipper-operator, please feel free to contribute it! Each example should include:
+
+1. **README.md** - Clear documentation with prerequisites, setup instructions, and usage
+2. **helmfile.yaml** or deployment manifests - Reproducible deployment configuration
+3. **Application code** - If applicable, well-documented source code
+4. **.gitignore** - To exclude build artifacts and sensitive data
+
+## Support
+
+For issues or questions about these examples:
+- Check the individual example's documentation
+- Review the main [pgskipper-operator documentation](../../README.md)
+- Open an issue in the [GitHub repository](https://github.com/Netcracker/pgskipper-operator/issues)

--- a/tests/examples/spring-boot-failover-test/.envrc.example
+++ b/tests/examples/spring-boot-failover-test/.envrc.example
@@ -1,0 +1,39 @@
+# Example environment configuration for helmfile
+# Copy this file to .envrc and adjust as needed
+# If using direnv, it will automatically load these variables when you cd into the directory
+
+# Image Configuration
+# -------------------
+
+# Use local build instead of official images (default: false)
+# export USE_LOCAL_IMAGES=true
+
+# Override operator image repository (default: ghcr.io/netcracker/pgskipper-operator)
+# export PGSKIPPER_IMAGE=ghcr.io/netcracker/pgskipper-operator
+
+# Override operator image tag (default: main)
+# export PGSKIPPER_TAG=v1.2.3
+
+# Deployment Configuration
+# -------------------------
+
+# Override PostgreSQL namespace (default: postgres)
+# export NAMESPACE=postgres
+
+# Override application namespace (default: default)
+# export APP_NAMESPACE=default
+
+# Usage Examples
+# --------------
+#
+# Deploy to OrbStack with official images:
+#   helmfile -e orbstack sync
+#
+# Deploy to OrbStack with local build:
+#   USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+#
+# Deploy to Rancher with specific version:
+#   PGSKIPPER_TAG=v1.2.3 helmfile -e rancher sync
+#
+# Deploy to cloud with custom image:
+#   PGSKIPPER_IMAGE=myregistry.io/pgskipper PGSKIPPER_TAG=custom helmfile sync

--- a/tests/examples/spring-boot-failover-test/.gitignore
+++ b/tests/examples/spring-boot-failover-test/.gitignore
@@ -1,0 +1,40 @@
+# Maven
+spring-app/target/
+spring-app/.mvn/
+spring-app/mvnw
+spring-app/mvnw.cmd
+
+# Buildpacks cache
+spring-app/.pack/
+.pack-build/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+*.swp
+*.swo
+.claude/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Kubernetes
+*.kubeconfig
+
+# Docker
+.dockerignore
+
+# Environment variables (direnv)
+.envrc
+
+# Temporary files
+tmp/
+temp/
+
+# Test outputs
+test-results/

--- a/tests/examples/spring-boot-failover-test/DEPLOYMENT.md
+++ b/tests/examples/spring-boot-failover-test/DEPLOYMENT.md
@@ -1,0 +1,288 @@
+# Deployment Configuration Guide
+
+This guide explains how to configure deployments using helmfile environments and environment variables.
+
+## Architecture
+
+The deployment configuration separates two concerns:
+
+1. **Environments** (`-e` flag) - Define **WHERE** to deploy (deployment target)
+2. **Environment Variables** - Define **WHAT** to deploy (image selection)
+
+## Environments
+
+Environments configure the deployment target (local vs cloud, storage, Docker context).
+
+### Available Environments
+
+| Environment | Description | Storage Class | Docker Context |
+|------------|-------------|---------------|----------------|
+| `default` | Cloud/remote Kubernetes | `standard` | `default` |
+| `local` | OrbStack (macOS) | `local-path` | `orbstack` |
+| `rancher` | Rancher Desktop | `local-path` | `rancher-desktop` |
+
+### Usage
+
+```bash
+# Deploy to default (cloud/remote)
+helmfile sync
+
+# Deploy to OrbStack
+helmfile -e orbstack sync
+
+# Deploy to Rancher Desktop
+helmfile -e rancher sync
+```
+
+## Image Configuration
+
+Image configuration is controlled by environment variables, allowing flexible image selection regardless of deployment target.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `USE_LOCAL_IMAGES` | Build and use local images | `false` |
+| `PGSKIPPER_IMAGE` | Operator image repository | `ghcr.io/netcracker/pgskipper-operator` |
+| `PGSKIPPER_TAG` | Operator image tag | `main` |
+| `NAMESPACE` | PostgreSQL namespace | `postgres` |
+| `APP_NAMESPACE` | Application namespace | `default` |
+
+### Usage Examples
+
+#### 1. Official Images (Default)
+
+Deploy using official images from GitHub Container Registry:
+
+```bash
+# To default environment (cloud)
+helmfile sync
+
+# To OrbStack
+helmfile -e orbstack sync
+
+# To Rancher Desktop
+helmfile -e rancher sync
+```
+
+#### 2. Local Development Build
+
+Build operator images locally and deploy:
+
+```bash
+# To OrbStack with local build
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+
+# To Rancher Desktop with local build
+USE_LOCAL_IMAGES=true helmfile -e rancher sync
+```
+
+**What happens:**
+1. Switches to appropriate Docker context (`orbstack` or `rancher-desktop`)
+2. Builds `pgskipper-operator:local` image locally
+3. Deploys with `imagePullPolicy: Never` (uses local image)
+
+#### 3. Specific Version
+
+Deploy a specific version from the registry:
+
+```bash
+# Deploy v1.2.3 to OrbStack
+PGSKIPPER_TAG=v1.2.3 helmfile -e orbstack sync
+
+# Deploy v1.2.3 to cloud
+PGSKIPPER_TAG=v1.2.3 helmfile sync
+```
+
+#### 4. Custom Registry
+
+Use images from a custom registry:
+
+```bash
+# Deploy from custom registry to OrbStack
+PGSKIPPER_IMAGE=myregistry.io/pgskipper PGSKIPPER_TAG=custom helmfile -e orbstack sync
+
+# Deploy from custom registry to cloud
+PGSKIPPER_IMAGE=myregistry.io/pgskipper PGSKIPPER_TAG=latest helmfile sync
+```
+
+#### 5. Custom Namespaces
+
+Override default namespaces:
+
+```bash
+# Deploy to custom namespaces on OrbStack
+NAMESPACE=my-postgres APP_NAMESPACE=my-app helmfile -e orbstack sync
+```
+
+## Using direnv (Recommended)
+
+For frequent local development, use [direnv](https://direnv.net/) to automatically set environment variables:
+
+```bash
+# Install direnv
+brew install direnv
+
+# Copy example configuration
+cp .envrc.example .envrc
+
+# Edit .envrc with your preferences
+vim .envrc
+
+# Allow direnv to load the file
+direnv allow
+```
+
+Example `.envrc` for local development:
+
+```bash
+# .envrc
+export USE_LOCAL_IMAGES=true
+export NAMESPACE=postgres
+export APP_NAMESPACE=default
+```
+
+Now simply:
+
+```bash
+cd postgresql-stability  # direnv automatically loads .envrc
+helmfile -e orbstack sync   # Uses local images automatically
+```
+
+## Common Workflows
+
+### Workflow 1: Local Development Cycle
+
+```bash
+# Initial setup with local images
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+
+# Make changes to operator code
+cd ../../../
+vim pkg/reconciler/patroni.go
+
+# Rebuild and redeploy
+cd tests/examples/spring-boot-failover-test
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+```
+
+### Workflow 2: Test Specific Version Locally
+
+```bash
+# Test version v1.2.3 on OrbStack before production deployment
+PGSKIPPER_TAG=v1.2.3 helmfile -e orbstack sync
+
+# Verify it works, then deploy to production
+PGSKIPPER_TAG=v1.2.3 helmfile sync
+```
+
+### Workflow 3: Multi-Environment Testing
+
+```bash
+# Test local build on OrbStack
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+
+# Test same build on Rancher Desktop
+USE_LOCAL_IMAGES=true helmfile -e rancher sync
+
+# Deploy official image to cloud
+helmfile sync
+```
+
+## Adding New Environments
+
+To add a new environment (e.g., `kind`):
+
+1. Create `environments/kind.yaml`:
+
+```yaml
+# Kind environment - for local development with kind
+storageClass: standard
+dockerContext: kind-kind
+```
+
+2. Register in `helmfile.yaml.gotmpl`:
+
+```yaml
+environments:
+  # ... existing environments ...
+  kind:
+    values:
+      - environments/kind.yaml
+```
+
+3. Use it:
+
+```bash
+USE_LOCAL_IMAGES=true helmfile -e kind sync
+```
+
+## Troubleshooting
+
+### Issue: Images not found in local Kubernetes
+
+**Symptom:** `ImagePullBackOff` with local images
+
+**Solution:** Verify Docker context matches environment:
+
+```bash
+# Check current context
+docker context ls
+
+# Should match environment's dockerContext setting
+# OrbStack: orbstack
+# Rancher: rancher-desktop
+# Kind: kind-kind
+
+# Switch if needed
+docker context use orbstack
+```
+
+### Issue: Wrong image version deployed
+
+**Symptom:** Deployed version doesn't match expectation
+
+**Solution:** Check environment variables:
+
+```bash
+# Show current configuration
+env | grep -E '(PGSKIPPER|USE_LOCAL)'
+
+# Clear variables if needed
+unset USE_LOCAL_IMAGES PGSKIPPER_TAG PGSKIPPER_IMAGE
+
+# Redeploy
+helmfile sync
+```
+
+### Issue: Build fails with "context not found"
+
+**Symptom:** Docker build fails with context error
+
+**Solution:** Ensure Docker context exists:
+
+```bash
+# List available contexts
+docker context ls
+
+# Create missing context (example for Rancher)
+docker context create rancher-desktop
+```
+
+## Best Practices
+
+1. **Use environments for infrastructure** - Storage classes, Docker contexts, cluster-specific settings
+2. **Use env vars for images** - Image repositories, tags, build flags
+3. **Use direnv for local dev** - Automate common settings
+4. **Version control environment files** - Commit to git
+5. **Don't version .envrc** - Add to `.gitignore` (personal settings)
+
+## Summary
+
+```bash
+# Quick reference
+helmfile sync                              # Official images → default (cloud)
+helmfile -e orbstack sync                     # Official images → OrbStack
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync  # Local build → OrbStack
+PGSKIPPER_TAG=v1.2.3 helmfile sync         # Specific version → cloud
+```

--- a/tests/examples/spring-boot-failover-test/README.md
+++ b/tests/examples/spring-boot-failover-test/README.md
@@ -1,0 +1,603 @@
+# Spring Boot PostgreSQL Failover Test Example
+
+**Location:** `tests/examples/spring-boot-failover-test/`
+
+## Overview
+
+This example demonstrates how to test PostgreSQL failover behavior with Spring Boot applications using HikariCP connection pooling and pgskipper-operator for high availability.
+
+## Problem Statement
+
+Java applications may fail to reconnect to a new primary PostgreSQL node after database failover, potentially causing service disruptions. This example helps:
+
+1. **Reproduce** the issue in a controlled environment
+2. **Monitor** connection behavior during failover events
+3. **Test** different connection pool configurations
+4. **Analyze** reconnection patterns and timing
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│           Kubernetes Cluster                    │
+│                                                  │
+│  ┌──────────────────────────────────────────┐  │
+│  │  Spring Boot Application (2 replicas)    │  │
+│  │  - HikariCP Connection Pool              │  │
+│  │  - Continuous Health Monitoring          │  │
+│  │  - REST API for Testing                  │  │
+│  └────────────┬─────────────────────────────┘  │
+│               │                                  │
+│               │ JDBC Connection                  │
+│               ▼                                  │
+│  ┌──────────────────────────────────────────┐  │
+│  │  PostgreSQL HA Cluster (pgskipper)       │  │
+│  │  ┌────────────┐  ┌────────────┐          │  │
+│  │  │  Primary   │  │  Replica 1 │          │  │
+│  │  │  (Master)  │  │  (Standby) │          │  │
+│  │  └────────────┘  └────────────┘          │  │
+│  │  ┌────────────┐                          │  │
+│  │  │  Replica 2 │  Patroni for HA          │  │
+│  │  │  (Standby) │  Auto-failover           │  │
+│  │  └────────────┘                          │  │
+│  └──────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
+```
+
+## Features
+
+### Spring Boot Application
+- **HikariCP Connection Pool** with optimized failover settings
+- **Multi-host JDBC URLs** for automatic failover support
+- **Health Monitoring** - Continuous connection checks every 5 seconds
+- **REST API Endpoints**:
+  - `/api/health` - Application and database health
+  - `/api/db-info` - Current database connection details (primary/replica, IP)
+  - `/api/pool-info` - Connection pool statistics
+  - `/api/monitor-stats` - Failover monitoring metrics
+  - `/api/write-test` - Test write operations
+  - `/api/read-test` - Test read operations
+  - `/api/test-connection` - Manual connection validation
+
+### PostgreSQL HA Cluster
+- **3-node cluster** (1 primary + 2 replicas)
+- **Automatic failover** using Patroni
+- **Streaming replication** for data synchronization
+- **Service discovery** for primary/replica routing
+
+### Monitoring & Testing
+- **Automated monitoring** with detailed logging
+- **Failover detection** and tracking
+- **Connection statistics** (uptime, failure count, recovery time)
+- **Scripts for testing** failover scenarios
+
+## Prerequisites
+
+**Note:** This example assumes you have cloned the pgskipper-operator repository and are working from within it.
+
+- **Kubernetes cluster** (local or cloud)
+  - Minikube, Kind, K3s, Docker Desktop, OrbStack, GKE, EKS, or AKS
+- **kubectl** - Kubernetes CLI tool
+- **Helm 3** - Kubernetes package manager
+- **helmfile** - Declarative Helm deployment tool
+- **Docker** - Container runtime
+- **Maven 3.9+** - For building the application (automatically called by helmfile)
+- **Java 17+** - For local development (optional)
+
+## Building the Application
+
+This project uses **Cloud Native Buildpacks** to build container images - no Dockerfile needed!
+
+### Quick Build
+
+```bash
+./scripts/build.sh
+```
+
+### Build Benefits
+
+- ✅ **No Dockerfile maintenance** - Buildpacks auto-configure everything
+- ✅ **Automatic security updates** - Rebuild to get latest patches
+- ✅ **SBOM included** - Software Bill of Materials for compliance
+- ✅ **Optimized caching** - Faster builds with intelligent layer reuse
+
+See [BUILDPACKS.md](BUILDPACKS.md) for advanced configuration.
+
+## Quick Start
+
+### 1. Navigate to Example Directory
+
+```bash
+# From pgskipper-operator repository root
+cd tests/examples/spring-boot-failover-test
+```
+
+### 2. Deploy Everything
+
+```bash
+# Deploy all components (storage, operators, PostgreSQL, application)
+helmfile sync
+
+# Or use apply for a diff preview first
+helmfile apply
+```
+
+This single command will:
+1. Configure storage automatically
+2. Install Patroni-Core operator
+3. Install Patroni-Services operator
+4. Wait for PostgreSQL cluster to be ready
+5. Build Spring Boot application Docker image
+6. Deploy the test application
+7. Display deployment status
+
+### 3. Verify Installation
+
+```bash
+# Check PostgreSQL cluster status
+kubectl get pods -n postgres -l app=postgres
+
+# Expected output:
+# NAME                              READY   STATUS    RESTARTS   AGE
+# postgres-cluster-0                1/1     Running   0          5m
+# postgres-cluster-1                1/1     Running   0          5m
+# postgres-cluster-2                1/1     Running   0          5m
+
+# Check application status
+kubectl get pods -n default -l app.kubernetes.io/name=postgresql-failover-test
+
+# View application logs
+kubectl logs -f -n default -l app.kubernetes.io/name=postgresql-failover-test
+```
+
+### 3. Test Failover
+
+Open two terminal windows:
+
+**Terminal 1 - Start monitoring:**
+```bash
+./scripts/test-reconnection.sh
+```
+
+**Terminal 2 - Trigger failover:**
+```bash
+./scripts/trigger-failover.sh
+```
+
+### 4. Analyze Results
+
+Monitor the output to observe:
+- **Connection loss detection** - How quickly the app detects the failure
+- **Failover duration** - Time for Patroni to promote a new primary
+- **Reconnection time** - How long the app takes to reconnect
+- **Connection stability** - Post-failover behavior
+
+### 5. Clean Up
+
+```bash
+# Remove all deployed components
+helmfile destroy
+
+# Remove CRDs (optional - WARNING: affects all pgskipper instances)
+kubectl delete crd patronicores.qubership.org patroniservices.qubership.org
+```
+
+## Advanced Usage
+
+### Environment Management
+
+The project supports multiple environments via `environments.yaml`:
+
+```bash
+# Deploy to local environment (default)
+helmfile -e orbstack sync
+
+# Deploy to minikube
+helmfile -e minikube sync
+
+# Deploy to development environment
+helmfile -e dev sync
+
+# Deploy to staging
+helmfile -e staging sync
+
+# Deploy to production (requires RELEASE_VERSION env var)
+RELEASE_VERSION=v1.0.0 helmfile -e prod sync
+```
+
+### Helmfile Commands
+
+```bash
+# Show what would change without applying
+helmfile diff
+
+# List all releases
+helmfile list
+
+# Check status of releases
+helmfile status
+
+# Sync only specific release
+helmfile -l component=postgres-operator sync
+
+# Sync only the application
+helmfile -l component=test-application sync
+
+# Template releases (show rendered manifests)
+helmfile template
+
+# Test releases
+helmfile test
+```
+
+### Manual Storage Configuration
+
+Storage is automatically configured during deployment. For manual configuration:
+
+```bash
+# Interactive mode
+./scripts/configure-storage.sh
+
+# Automatic mode (no prompts)
+./scripts/configure-storage.sh --auto
+```
+
+### Building the Application Manually
+
+The application is automatically built during deployment. To build manually:
+
+```bash
+# Build Docker image
+./scripts/build.sh
+
+# Build with custom tag
+IMAGE_TAG=v1.0.0 ./scripts/build.sh
+```
+
+## Configuration
+
+### HikariCP Connection Pool Settings
+
+Edit `spring-app/src/main/resources/application.yml`:
+
+```yaml
+spring:
+  datasource:
+    hikari:
+      minimum-idle: 2
+      maximum-pool-size: 10
+      connection-timeout: 10000      # 10 seconds
+      validation-timeout: 5000       # 5 seconds
+      max-lifetime: 600000           # 10 minutes
+      idle-timeout: 300000           # 5 minutes
+      connection-test-query: SELECT 1
+```
+
+### Multi-Host JDBC URL
+
+The application uses a multi-host JDBC URL for failover:
+
+```
+jdbc:postgresql://host1:5432,host2:5432,host3:5432/testdb?targetServerType=primary&loadBalanceHosts=true
+```
+
+Key parameters:
+- `targetServerType=primary` - Always connect to primary (read-write)
+- `loadBalanceHosts=true` - Try hosts in random order
+- `connectTimeout=10` - Socket connection timeout (seconds)
+- `socketTimeout=30` - Socket read timeout (seconds)
+- `tcpKeepAlive=true` - Enable TCP keepalive
+
+### PostgreSQL Cluster Configuration
+
+Edit `helm-charts/postgresql/patroni-core-values.yaml`:
+
+```yaml
+patroniCore:
+  topology:
+    replicas: 3  # Number of PostgreSQL instances
+
+  storage:
+    storageClassName: "standard"  # Update for your cluster
+    size: "10Gi"
+
+  patroni:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+```
+
+## Testing Scenarios
+
+### Scenario 1: Basic Failover Test
+
+```bash
+# Start monitoring
+./scripts/test-reconnection.sh
+
+# In another terminal, trigger failover
+./scripts/trigger-failover.sh
+```
+
+**Expected behavior:**
+- Application detects connection loss within 5-10 seconds
+- Patroni promotes replica to primary within 30-60 seconds
+- Application reconnects automatically within 10-20 seconds
+
+### Scenario 2: Load Testing During Failover
+
+```bash
+# Port forward to access the application
+kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+
+# Run continuous write operations
+while true; do
+  curl -X POST "http://localhost:8080/api/write-test?message=Load+test+$(date +%s)"
+  sleep 1
+done
+
+# In another terminal, trigger failover
+./scripts/trigger-failover.sh
+```
+
+### Scenario 3: Multiple Failovers
+
+```bash
+# Trigger multiple failovers to test stability
+./scripts/trigger-failover.sh
+sleep 120
+./scripts/trigger-failover.sh
+sleep 120
+./scripts/trigger-failover.sh
+```
+
+## Monitoring and Debugging
+
+### Application Logs
+
+```bash
+# Follow application logs
+kubectl logs -f -n default -l app.kubernetes.io/name=postgresql-failover-test
+
+# Search for connection events
+kubectl logs -n default -l app.kubernetes.io/name=postgresql-failover-test | grep -i "connection\|failover"
+```
+
+### Database Status
+
+```bash
+# Get current primary
+kubectl get pods -n postgres --selector=pgtype=master
+
+# Check Patroni cluster status
+kubectl exec -n postgres postgres-cluster-0 -- patronictl list
+
+# Check PostgreSQL replication
+kubectl exec -n postgres postgres-cluster-0 -- psql -U postgres -c "SELECT * FROM pg_stat_replication;"
+```
+
+### API Endpoints (via port-forward)
+
+```bash
+# Port forward to application
+kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+
+# Get current database info
+curl http://localhost:8080/api/db-info
+
+# Get monitoring statistics
+curl http://localhost:8080/api/monitor-stats
+
+# Test connection
+curl http://localhost:8080/api/test-connection
+
+# Write test data
+curl -X POST "http://localhost:8080/api/write-test?message=Test"
+
+# Read test data
+curl http://localhost:8080/api/read-test
+```
+
+## Common Issues and Solutions
+
+### Issue: Application fails to reconnect after failover
+
+**Symptoms:**
+- Application logs show persistent connection errors
+- Monitor stats show high failure count
+- Health endpoint returns 503
+
+**Solutions:**
+
+1. **Check JDBC URL configuration:**
+   ```bash
+   kubectl get configmap postgresql-failover-test-config -o yaml
+   ```
+   Ensure it includes all PostgreSQL hosts and `targetServerType=primary`
+
+2. **Increase connection timeout:**
+   Edit `application.yml` and increase:
+   ```yaml
+   hikari:
+     connection-timeout: 20000  # 20 seconds
+     validation-timeout: 10000  # 10 seconds
+   ```
+
+3. **Verify PostgreSQL service:**
+   ```bash
+   kubectl get svc -n postgres
+   kubectl describe svc postgres-service -n postgres
+   ```
+
+### Issue: Slow failover (>2 minutes)
+
+**Symptoms:**
+- Patroni takes long to promote replica
+- Application downtime exceeds 2 minutes
+
+**Solutions:**
+
+1. **Adjust Patroni settings:**
+   Edit `patroni-core-values.yaml`:
+   ```yaml
+   patroni:
+     ttl: 20              # Reduce from 30
+     loop_wait: 5         # Reduce from 10
+     retry_timeout: 5     # Reduce from 10
+   ```
+
+2. **Check resource constraints:**
+   ```bash
+   kubectl top pods -n postgres
+   ```
+
+### Issue: Connection pool exhaustion
+
+**Symptoms:**
+- "Connection timeout" errors
+- Application becomes unresponsive
+
+**Solutions:**
+
+1. **Increase pool size:**
+   ```yaml
+   hikari:
+     maximum-pool-size: 20  # Increase from 10
+   ```
+
+2. **Check for connection leaks:**
+   ```bash
+   curl http://localhost:8080/api/pool-info
+   ```
+
+## Performance Tuning
+
+### For Faster Failover Detection
+
+1. **Reduce connection validation timeout:**
+   ```yaml
+   hikari:
+     validation-timeout: 3000  # 3 seconds
+   ```
+
+2. **Enable TCP keepalive with shorter intervals:**
+   ```yaml
+   data-source-properties:
+     tcpKeepAlive: true
+     socketTimeout: 15  # 15 seconds instead of 30
+   ```
+
+### For Better Connection Stability
+
+1. **Increase max lifetime:**
+   ```yaml
+   hikari:
+     max-lifetime: 1800000  # 30 minutes
+   ```
+
+2. **Use connection validation on borrow:**
+   ```yaml
+   hikari:
+     connection-test-query: SELECT 1
+   ```
+
+## Project Structure
+
+```
+postgresql-stability/
+├── helmfile.yaml                    # Main helmfile configuration
+├── environments.yaml                # Environment-specific settings
+├── spring-app/                      # Spring Boot application
+│   ├── src/main/java/
+│   │   └── com/example/pgtest/
+│   │       ├── Application.java     # Main class
+│   │       ├── controller/
+│   │       │   └── HealthController.java  # REST endpoints
+│   │       ├── service/
+│   │       │   ├── DatabaseService.java   # DB operations
+│   │       │   └── ConnectionMonitor.java # Health monitoring
+│   │       ├── repository/
+│   │       │   └── TestRepository.java
+│   │       └── model/
+│   │           └── TestEntity.java
+│   ├── src/main/resources/
+│   │   ├── application.yml          # Spring Boot config
+│   │   └── schema.sql
+│   └── pom.xml                      # Maven dependencies
+├── helm-charts/
+│   ├── spring-app/                  # Application Helm chart
+│   │   ├── Chart.yaml
+│   │   ├── values.yaml
+│   │   └── templates/
+│   └── postgresql/                  # pgskipper configurations
+│       ├── patroni-core-minimal.yaml
+│       └── patroni-services-minimal.yaml
+├── scripts/
+│   ├── build.sh                     # Build Docker image
+│   ├── configure-storage.sh         # Storage configuration
+│   ├── trigger-failover.sh          # Failover testing
+│   └── test-reconnection.sh         # Connection monitoring
+├── pgskipper-operator/              # Auto-cloned operator repository
+└── README.md
+```
+
+## Comparison with Shell Scripts
+
+### Old Approach (Shell Scripts)
+```bash
+./scripts/setup.sh      # Setup everything
+./scripts/cleanup.sh    # Clean up (with prompts)
+```
+
+**Issues:**
+- Manual sleep/wait loops
+- Interactive prompts blocking automation
+- Manual PVC patching after deployment
+- Hard to manage multiple environments
+- No built-in diffing or rollback
+
+### New Approach (Helmfile)
+```bash
+helmfile sync           # Setup everything
+helmfile destroy        # Clean up (no prompts)
+```
+
+**Benefits:**
+- ✅ Declarative configuration
+- ✅ Idempotent operations
+- ✅ Automatic dependency management
+- ✅ Built-in diffing and preview
+- ✅ Environment management
+- ✅ No manual wait loops or sleep statements
+- ✅ Better error handling and rollback
+- ✅ Version controlled configuration
+
+## Technology Stack
+
+- **Spring Boot 3.2.0** - Application framework
+- **Spring Data JPA** - Database access
+- **HikariCP** - Connection pooling
+- **PostgreSQL 15** - Database
+- **Patroni** - PostgreSQL HA solution
+- **pgskipper-operator** - Kubernetes operator for PostgreSQL
+- **Helmfile** - Declarative Helm deployment
+- **Helm 3** - Kubernetes package manager
+- **Maven** - Build tool
+
+## References
+
+- [pgskipper-operator Documentation](../../../README.md) - Main operator documentation
+- [pgskipper-operator Repository](https://github.com/Netcracker/pgskipper-operator)
+- [Helmfile Documentation](https://helmfile.readthedocs.io/)
+- [Patroni Documentation](https://patroni.readthedocs.io/)
+- [HikariCP Configuration](https://github.com/brettwooldridge/HikariCP)
+- [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/documentation/)
+- [Spring Boot Data Access](https://docs.spring.io/spring-boot/docs/current/reference/html/data.html)
+
+## Contributing
+
+Feel free to submit issues or pull requests to improve this testing framework.
+
+## License
+
+This project is provided as-is for testing and educational purposes.

--- a/tests/examples/spring-boot-failover-test/REFACTORING_SUMMARY.md
+++ b/tests/examples/spring-boot-failover-test/REFACTORING_SUMMARY.md
@@ -1,0 +1,196 @@
+# Helmfile Configuration Refactoring Summary
+
+## Changes Made
+
+### 1. Separated Concerns
+
+**Before:** Environments controlled both deployment target AND image selection
+**After:**
+- **Environments** = WHERE to deploy (OrbStack, Rancher, Cloud)
+- **Environment Variables** = WHAT to deploy (image repos, tags, local builds)
+
+### 2. Environment Files Simplified
+
+**Before (`environments/local.yaml`):**
+```yaml
+storageClass: local-path
+pgskipperOperator:
+  useLocalBuild: true
+  coreImage:
+    repository: pgskipper-operator
+    tag: local
+  pullPolicy: Never
+```
+
+**After (`environments/local.yaml`):**
+```yaml
+# OrbStack environment - for local development with OrbStack
+storageClass: local-path
+dockerContext: orbstack
+```
+
+Environment files now only contain deployment-target-specific configuration.
+
+### 3. Image Configuration via Environment Variables
+
+Added support for environment variables to control image selection:
+
+```bash
+USE_LOCAL_IMAGES=true          # Build locally vs use registry
+PGSKIPPER_IMAGE=<registry>     # Override image repository
+PGSKIPPER_TAG=<tag>            # Override image tag
+```
+
+### 4. helmfile.yaml.gotmpl Changes
+
+- Added variable parsing from environment
+- Image configuration logic at the top of the file
+- Hooks now respect `USE_LOCAL_IMAGES` environment variable
+- Automatic Docker context switching based on environment
+
+### 5. New Files Created
+
+1. **`.envrc.example`** - Example direnv configuration
+2. **`DEPLOYMENT.md`** - Comprehensive deployment guide
+3. **`REFACTORING_SUMMARY.md`** (this file) - Summary of changes
+4. **`environments/rancher.yaml`** - Rancher Desktop environment
+
+### 6. Updated .gitignore
+
+Added `.envrc` to prevent committing personal environment settings.
+
+## Migration Guide
+
+### Old Usage → New Usage
+
+| Old Command | New Command |
+|------------|-------------|
+| `helmfile -e orbstack sync` | `USE_LOCAL_IMAGES=true helmfile -e orbstack sync` |
+| `helmfile sync` | `helmfile sync` (no change) |
+
+### Breaking Changes
+
+**Before:** `helmfile -e orbstack sync` automatically built local images
+
+**After:** Need to explicitly set `USE_LOCAL_IMAGES=true`
+
+**Workaround:** Use direnv with `.envrc`:
+```bash
+export USE_LOCAL_IMAGES=true
+```
+
+Then `helmfile -e orbstack sync` works as before.
+
+## Benefits
+
+### 1. Flexibility
+```bash
+# Same environment, different images
+helmfile -e orbstack sync                      # Official images on OrbStack
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync   # Local images on OrbStack
+PGSKIPPER_TAG=v1.2.3 helmfile -e orbstack sync    # Specific version on OrbStack
+```
+
+### 2. Clarity
+```bash
+# Environment = deployment target
+-e local     # Deploy to OrbStack
+-e rancher   # Deploy to Rancher Desktop
+(default)    # Deploy to cloud/remote
+
+# Variables = what to deploy
+USE_LOCAL_IMAGES=true    # Local build
+PGSKIPPER_TAG=v1.2.3     # Specific version
+```
+
+### 3. Extensibility
+
+Easy to add new environments without duplicating image configuration:
+
+```yaml
+# environments/kind.yaml
+storageClass: standard
+dockerContext: kind-kind
+```
+
+All image options (local build, specific versions, custom registries) automatically work with new environment.
+
+### 4. Composability
+
+Mix and match environments and image configurations:
+
+```bash
+# Test matrix
+for env in local rancher kind; do
+  for tag in v1.2.3 v1.2.4 main; do
+    PGSKIPPER_TAG=$tag helmfile -e $env sync
+  done
+done
+```
+
+## Usage Examples
+
+### Local Development Workflow
+
+**With direnv:**
+```bash
+# .envrc
+export USE_LOCAL_IMAGES=true
+
+# Now simply:
+helmfile -e orbstack sync
+```
+
+**Without direnv:**
+```bash
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+```
+
+### CI/CD Pipeline
+
+```bash
+# Deploy specific version to staging (OrbStack)
+PGSKIPPER_TAG=${CI_COMMIT_TAG} helmfile -e orbstack sync
+
+# Deploy to production (cloud)
+PGSKIPPER_TAG=${CI_COMMIT_TAG} helmfile sync
+```
+
+### Testing
+
+```bash
+# Test local build on multiple environments
+for env in local rancher kind; do
+  USE_LOCAL_IMAGES=true helmfile -e $env sync
+  ./scripts/run-tests.sh
+  helmfile -e $env destroy
+done
+```
+
+## Files Changed
+
+1. ✏️ `helmfile.yaml.gotmpl` - Added env var support, refactored image config
+2. ✏️ `environments/default.yaml` - Removed image config, kept deployment config
+3. ✏️ `environments/local.yaml` - Removed image config, kept deployment config
+4. ✏️ `environments/rancher.yaml` - Created (deployment config only)
+5. ✏️ `.gitignore` - Added `.envrc`
+6. ➕ `.envrc.example` - Created
+7. ➕ `DEPLOYMENT.md` - Created
+8. ➕ `REFACTORING_SUMMARY.md` - Created
+
+## Backward Compatibility
+
+The refactoring maintains backward compatibility with one exception:
+
+**Removed:** Auto-detection of local environment triggering local build
+
+**Reason:** Mixing deployment target with image selection creates inflexibility
+
+**Mitigation:** Use direnv or set `USE_LOCAL_IMAGES=true` explicitly
+
+## Next Steps
+
+1. Review `DEPLOYMENT.md` for complete usage guide
+2. Copy `.envrc.example` to `.envrc` if using direnv
+3. Update CI/CD pipelines to use environment variables
+4. Consider adding more environments (kind, k3d, etc.)

--- a/tests/examples/spring-boot-failover-test/docs/BUILDPACKS.md
+++ b/tests/examples/spring-boot-failover-test/docs/BUILDPACKS.md
@@ -1,0 +1,304 @@
+# Building with Cloud Native Buildpacks
+
+This project uses **Cloud Native Buildpacks** to build container images, eliminating the need for Dockerfile maintenance while providing automatic security updates and optimizations.
+
+## What are Cloud Native Buildpacks?
+
+Cloud Native Buildpacks (CNB) transform your application source code into container images without requiring a Dockerfile. They provide:
+
+- **No Dockerfile needed** - Buildpacks detect and configure your application automatically
+- **Automatic security updates** - Base images and dependencies stay current
+- **Optimized layer caching** - Faster builds with intelligent layer reuse
+- **Language best practices** - Production-ready configurations out of the box
+- **SBOM generation** - Software Bill of Materials for security compliance
+- **Reproducible builds** - Consistent images across environments
+
+## Building the Image
+
+### Using the Build Script (Recommended)
+
+```bash
+# From project root
+./scripts/build.sh
+
+# With custom image name/tag
+IMAGE_NAME=myapp IMAGE_TAG=v1.0 ./scripts/build.sh
+```
+
+### Manual Build
+
+```bash
+# From spring-app directory
+cd spring-app
+mvn spring-boot:build-image
+```
+
+**Configuration in `pom.xml`:**
+```xml
+<plugin>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-maven-plugin</artifactId>
+    <configuration>
+        <image>
+            <name>postgresql-failover-test:${project.version}</name>
+            <env>
+                <BP_JVM_VERSION>17</BP_JVM_VERSION>
+                <BPE_APPEND_JAVA_TOOL_OPTIONS>-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0</BPE_APPEND_JAVA_TOOL_OPTIONS>
+            </env>
+        </image>
+    </configuration>
+</plugin>
+```
+
+### Alternative: Pack CLI
+
+For advanced use cases, you can use the Pack CLI directly:
+
+```bash
+# Install Pack CLI
+brew install buildpacks/tap/pack  # macOS
+
+# Build with Pack
+cd spring-app
+pack build postgresql-failover-test:latest \
+    --builder paketobuildpacks/builder:base \
+    --path .
+```
+
+## Configuration
+
+### Project Descriptor (`project.toml`)
+
+Customize buildpack behavior with `spring-app/project.toml`:
+
+```toml
+[build]
+  include = ["src/", "pom.xml"]
+  exclude = ["target/", ".git/"]
+
+[[build.env]]
+name = "BP_JVM_VERSION"
+value = "17"
+
+[[build.env]]
+name = "BP_JVM_TYPE"
+value = "JRE"  # Use JRE for smaller images
+```
+
+### Environment Variables
+
+Key buildpack environment variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `BP_JVM_VERSION` | Java version to use | `17`, `21` |
+| `BP_JVM_TYPE` | JDK or JRE | `JRE`, `JDK` |
+| `BP_MAVEN_BUILD_ARGUMENTS` | Maven build args | `clean package -DskipTests` |
+| `BPE_APPEND_JAVA_TOOL_OPTIONS` | Additional JVM options | `-XX:MaxRAMPercentage=75.0` |
+| `BP_JVM_JLINK_ENABLED` | Create custom JRE with jlink | `true`, `false` |
+
+### Maven Plugin Configuration
+
+Override settings at build time:
+
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.imageName=myapp:1.0 \
+    -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny \
+    -Dspring-boot.build-image.env.BP_JVM_VERSION=21
+```
+
+## Available Builders
+
+Different builders for different use cases:
+
+| Builder | Use Case | Size |
+|---------|----------|------|
+| `paketobuildpacks/builder:base` | General purpose (default) | ~1GB |
+| `paketobuildpacks/builder:full` | All features, languages | ~1.5GB |
+| `paketobuildpacks/builder:tiny` | Minimal, distroless | ~500MB |
+
+Example using tiny builder:
+
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+```
+
+## Key Advantages
+
+### 1. Zero Maintenance
+- No Dockerfile to maintain
+- Security patches applied automatically on rebuild
+- Language runtime updates handled by buildpack
+
+### 2. Optimized Caching
+Buildpacks create intelligent layers automatically:
+- Dependencies layer (cached unless pom.xml changes)
+- Application layer (cached unless source changes)
+- JRE layer (cached unless version changes)
+
+### 3. Security & Compliance
+```bash
+# Extract SBOM (Software Bill of Materials)
+docker run --rm postgresql-failover-test:latest \
+    cat /layers/sbom/launch/paketo-buildpacks_*/sbom.syft.json > sbom.json
+
+# Analyze for vulnerabilities
+grype postgresql-failover-test:latest
+```
+
+### 4. Reproducible Builds
+Same source code + same buildpack version = identical image
+- Useful for debugging
+- Compliance requirements
+- Audit trails
+
+## Integration with CI/CD
+
+### GitHub Actions
+
+```yaml
+- name: Build with Buildpacks
+  run: |
+    mvn spring-boot:build-image \
+      -Dspring-boot.build-image.imageName=${{ secrets.REGISTRY }}/app:${{ github.sha }}
+
+- name: Push image
+  run: docker push ${{ secrets.REGISTRY }}/app:${{ github.sha }}
+```
+
+### GitLab CI
+
+```yaml
+build:
+  image: maven:3.9-eclipse-temurin-17
+  script:
+    - mvn spring-boot:build-image -DskipTests
+  services:
+    - docker:dind
+```
+
+### Jenkins
+
+```groovy
+stage('Build') {
+    steps {
+        sh 'mvn spring-boot:build-image'
+    }
+}
+```
+
+## Troubleshooting
+
+### Issue: Build fails with "Cannot connect to Docker daemon"
+
+**Solution:** Ensure Docker is running:
+```bash
+docker ps
+```
+
+### Issue: Build is slow on first run
+
+**Solution:** This is normal. Buildpacks download and cache dependencies. Subsequent builds will be much faster.
+
+### Issue: Want smaller images
+
+**Solution 1:** Use tiny builder:
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+```
+
+**Solution 2:** Enable jlink:
+```xml
+<env>
+    <BP_JVM_JLINK_ENABLED>true</BP_JVM_JLINK_ENABLED>
+    <BP_JVM_JLINK_ARGS>--no-man-pages --no-header-files --strip-debug</BP_JVM_JLINK_ARGS>
+</env>
+```
+
+### Issue: Need custom buildpack
+
+**Solution:** Add custom buildpack:
+```xml
+<buildpacks>
+    <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
+    <buildpack>docker://my-custom-buildpack:latest</buildpack>
+</buildpacks>
+```
+
+## Advanced Features
+
+### Layer Analysis
+
+Inspect image layers:
+```bash
+pack inspect-image postgresql-failover-test:latest
+```
+
+### Rebasing (Update base image without rebuild)
+
+```bash
+pack rebase postgresql-failover-test:latest \
+    --run-image paketobuildpacks/run:base-cnb
+```
+
+### Build from Git
+
+```bash
+pack build postgresql-failover-test:latest \
+    --builder paketobuildpacks/builder:base \
+    --path https://github.com/user/repo.git
+```
+
+### Multi-arch Builds
+
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.platforms=linux/amd64,linux/arm64
+```
+
+## Quick Start
+
+1. **Build the image:**
+   ```bash
+   ./scripts/build-with-buildpacks.sh
+   ```
+
+2. **Run locally:**
+   ```bash
+   docker run -p 8080:8080 \
+       -e DATABASE_URL=jdbc:postgresql://localhost:5432/testdb \
+       postgresql-failover-test:latest
+   ```
+
+3. **Deploy to Kubernetes:**
+   ```bash
+   kubectl apply -f k8s/deployment.yaml
+   ```
+
+## Resources
+
+- [Cloud Native Buildpacks](https://buildpacks.io/)
+- [Paketo Buildpacks](https://paketo.io/)
+- [Spring Boot Buildpacks](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#build-image)
+- [Pack CLI Reference](https://buildpacks.io/docs/tools/pack/)
+
+## Quick Start
+
+```bash
+# 1. Build the image
+./scripts/build.sh
+
+# 2. Run locally with Docker
+docker run -p 8080:8080 \
+    -e DATABASE_URL=jdbc:postgresql://localhost:5432/testdb \
+    postgresql-failover-test:latest
+
+# 3. Test the application
+curl http://localhost:8080/api/health
+
+# 4. Or deploy to Kubernetes
+./scripts/setup.sh
+```

--- a/tests/examples/spring-boot-failover-test/docs/DEVELOPMENT.md
+++ b/tests/examples/spring-boot-failover-test/docs/DEVELOPMENT.md
@@ -1,0 +1,580 @@
+# Development Guide - Spring Boot Failover Test
+
+**Location:** `tests/examples/spring-boot-failover-test/`
+
+This guide provides comprehensive development instructions for working with the PostgreSQL failover test example.
+
+## Primary Goal
+
+This project provides a **controlled test environment to reproduce and analyze PostgreSQL failover behavior** with Java Spring Boot applications using HikariCP connection pooling.
+
+### The Problem
+
+Java applications may fail to reconnect to a new primary PostgreSQL node after database failover, potentially causing service disruptions. This happens because:
+
+1. Connection pools may cache stale connections to the failed primary
+2. JDBC drivers may not immediately detect primary node changes
+3. Connection validation settings may be insufficient
+4. Multi-host JDBC URL configuration may be incorrect
+
+### The Solution
+
+This project helps you:
+
+- **Reproduce** the issue in a controlled Kubernetes environment
+- **Monitor** connection behavior during failover events with detailed metrics
+- **Test** different connection pool configurations (HikariCP settings)
+- **Analyze** reconnection patterns, timing, and failure recovery
+- **Validate** fixes and optimizations before production deployment
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────┐
+│           Kubernetes Cluster                    │
+│                                                  │
+│  ┌──────────────────────────────────────────┐  │
+│  │  Spring Boot Application (2 replicas)    │  │
+│  │  - HikariCP Connection Pool              │  │
+│  │  - Continuous Health Monitoring          │  │
+│  │  - REST API for Testing                  │  │
+│  └────────────┬─────────────────────────────┘  │
+│               │                                  │
+│               │ JDBC Multi-Host Connection       │
+│               ▼                                  │
+│  ┌──────────────────────────────────────────┐  │
+│  │  PostgreSQL HA Cluster (pgskipper)       │  │
+│  │  ┌────────────┐  ┌────────────┐          │  │
+│  │  │  Primary   │  │  Replica 1 │          │  │
+│  │  │  (Master)  │  │  (Standby) │          │  │
+│  │  └────────────┘  └────────────┘          │  │
+│  │  ┌────────────┐                          │  │
+│  │  │  Replica 2 │  Patroni for HA          │  │
+│  │  │  (Standby) │  Auto-failover           │  │
+│  │  └────────────┘                          │  │
+│  └──────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+1. **PostgreSQL HA Cluster**
+   - 3-node cluster (1 primary + 2 replicas)
+   - Managed by pgskipper-operator (Patroni-based)
+   - Automatic failover detection and promotion
+   - Streaming replication
+
+2. **Spring Boot Test Application**
+   - HikariCP connection pool with configurable settings
+   - Multi-host JDBC URL for automatic failover
+   - Continuous connection health monitoring (every 5 seconds)
+   - REST API for testing and metrics
+
+3. **Monitoring & Observability**
+   - Real-time connection status tracking
+   - Failover detection and timing metrics
+   - Connection pool statistics
+   - Detailed logging of reconnection attempts
+
+## Deployment Instructions
+
+### Prerequisites
+
+Ensure you have the following installed:
+
+- **Kubernetes cluster** (Docker Desktop, OrbStack, Minikube, Kind, or cloud provider)
+- **kubectl** - Kubernetes CLI
+- **helm** - Kubernetes package manager (v3+)
+- **helmfile** - Declarative Helm deployment tool
+- **docker** - Container runtime
+- **git** - Version control
+
+#### Install Helmfile
+
+```bash
+# macOS
+brew install helmfile
+
+# Linux
+curl -L https://github.com/helmfile/helmfile/releases/latest/download/helmfile_linux_amd64 -o helmfile
+chmod +x helmfile
+sudo mv helmfile /usr/local/bin/
+
+# Windows
+choco install helmfile
+```
+
+### Step 1: Verify Kubernetes Cluster
+
+```bash
+# Check cluster connectivity
+kubectl cluster-info
+
+# Verify cluster is ready
+kubectl get nodes
+```
+
+### Step 2: Deploy Everything
+
+```bash
+# Navigate to example directory
+cd tests/examples/spring-boot-failover-test
+
+# Deploy all components (one command!)
+helmfile sync
+```
+
+This single command will:
+1. ✅ Auto-configure storage for your cluster
+2. ✅ Install Patroni-Core operator (PostgreSQL core)
+3. ✅ Install Patroni-Services operator (PostgreSQL services)
+4. ✅ Wait for PostgreSQL cluster to be ready
+5. ✅ Build Spring Boot application Docker image
+6. ✅ Deploy the test application (2 replicas)
+7. ✅ Display deployment status
+
+**Expected output:**
+```
+Building Spring Boot application Docker image...
+✓ Docker image built successfully
+
+Waiting for PostgreSQL cluster to initialize...
+Waiting for primary PostgreSQL pod...
+PostgreSQL cluster is ready!
+
+Waiting for application pods to be ready...
+Application is ready!
+
+=====================================
+Deployment Complete!
+=====================================
+```
+
+### Step 3: Verify Deployment
+
+```bash
+# Check PostgreSQL cluster status
+kubectl get pods -n postgres -l app=postgres
+
+# Expected output:
+# NAME                 READY   STATUS    RESTARTS   AGE
+# postgres-cluster-0   1/1     Running   0          2m
+# postgres-cluster-1   1/1     Running   0          2m
+# postgres-cluster-2   1/1     Running   0          2m
+
+# Check application status
+kubectl get pods -n default -l app.kubernetes.io/name=postgresql-failover-test
+
+# Expected output:
+# NAME                                       READY   STATUS    RESTARTS   AGE
+# postgresql-failover-test-xxxxxxxxx-xxxxx   1/1     Running   0          1m
+# postgresql-failover-test-xxxxxxxxx-xxxxx   1/1     Running   0          1m
+
+# View application logs
+kubectl logs -f -n default -l app.kubernetes.io/name=postgresql-failover-test
+```
+
+## Failover Testing Instructions
+
+### Test Scenario: Simulated PostgreSQL Failover
+
+This test simulates a real-world scenario where the primary PostgreSQL database fails and Patroni automatically promotes a replica to become the new primary.
+
+#### Step 1: Start Connection Monitoring
+
+Open a terminal window and start the monitoring script:
+
+```bash
+./scripts/test-reconnection.sh
+```
+
+**What this does:**
+- Continuously queries the application's monitoring endpoint
+- Displays real-time connection status
+- Shows metrics: uptime, failure count, current database node
+- Updates every 2 seconds
+
+**Expected output:**
+```
+==========================================
+PostgreSQL Failover Reconnection Monitor
+==========================================
+
+[2025-10-06 10:30:15] ✓ Connected | Uptime: 120s | Failures: 0 | Current DB: postgres-cluster-0
+
+[2025-10-06 10:30:17] ✓ Connected | Uptime: 122s | Failures: 0 | Current DB: postgres-cluster-0
+
+[2025-10-06 10:30:19] ✓ Connected | Uptime: 124s | Failures: 0 | Current DB: postgres-cluster-0
+```
+
+#### Step 2: Trigger Failover
+
+Open a **second terminal window** and trigger the failover:
+
+```bash
+./scripts/trigger-failover.sh
+```
+
+**What this does:**
+1. Identifies the current primary PostgreSQL pod
+2. Deletes the primary pod to simulate a failure
+3. Patroni automatically detects the failure
+4. One of the replicas is promoted to new primary
+5. Kubernetes recreates the deleted pod as a new replica
+
+**Expected output:**
+```
+==========================================
+PostgreSQL Failover Test
+==========================================
+
+Current primary pod: postgres-cluster-0
+Triggering failover by deleting primary pod...
+pod "postgres-cluster-0" deleted
+
+Waiting for new primary election...
+New primary elected: postgres-cluster-1
+
+Failover complete!
+==========================================
+```
+
+#### Step 3: Observe Application Behavior
+
+Watch the monitoring terminal (from Step 1). You should observe:
+
+**Phase 1: Connection Loss Detection (5-10 seconds)**
+```
+[2025-10-06 10:30:21] ✗ DISCONNECTED | Last connected: 2s ago | Failures: 1
+[2025-10-06 10:30:23] ✗ DISCONNECTED | Last connected: 4s ago | Failures: 1
+[2025-10-06 10:30:25] ✗ DISCONNECTED | Last connected: 6s ago | Failures: 1
+```
+
+**Phase 2: Patroni Failover (30-60 seconds)**
+- Patroni detects primary failure
+- Replica promotion happens
+- New primary is ready
+
+**Phase 3: Application Reconnection (10-20 seconds)**
+```
+[2025-10-06 10:30:45] ✓ Connected | Uptime: 5s | Failures: 1 | Current DB: postgres-cluster-1
+[2025-10-06 10:30:47] ✓ Connected | Uptime: 7s | Failures: 1 | Current DB: postgres-cluster-1
+[2025-10-06 10:30:49] ✓ Connected | Uptime: 9s | Failures: 1 | Current DB: postgres-cluster-1
+```
+
+**Key Metrics to Track:**
+- **Detection Time**: How quickly app detects connection loss (should be < 10s)
+- **Failover Duration**: Time for new primary election (typically 30-60s)
+- **Reconnection Time**: How long app takes to reconnect (should be < 20s)
+- **Total Downtime**: From connection loss to recovery (should be < 90s)
+- **Failure Count**: Should increment by 1 after each failover
+
+#### Step 4: Verify New Primary
+
+Check which pod is now the primary:
+
+```bash
+# Check primary pod
+kubectl get pods -n postgres --selector=pgtype=master
+
+# Verify Patroni cluster status
+kubectl exec -n postgres postgres-cluster-1 -- patronictl list
+```
+
+Expected output showing the new topology:
+```
++ Cluster: postgres (7123456789012345678) ----+----+-----------+
+| Member             | Host        | Role    | State   | Lag in MB |
++--------------------+-------------+---------+---------+-----------+
+| postgres-cluster-1 | 10.244.0.15 | Leader  | running |           |
+| postgres-cluster-2 | 10.244.0.16 | Replica | running | 0         |
+| postgres-cluster-0 | 10.244.0.17 | Replica | running | 0         |
++--------------------+-------------+---------+---------+-----------+
+```
+
+### Advanced Testing Scenarios
+
+#### Scenario 1: Load Testing During Failover
+
+Test application behavior under load:
+
+```bash
+# Port forward to application
+kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+
+# Run continuous write operations (in a new terminal)
+while true; do
+  curl -X POST "http://localhost:8080/api/write-test?message=Load+test+$(date +%s)"
+  sleep 1
+done
+
+# Trigger failover (in another terminal)
+./scripts/trigger-failover.sh
+```
+
+Monitor how many write operations fail during failover.
+
+#### Scenario 2: Multiple Sequential Failovers
+
+Test stability across multiple failovers:
+
+```bash
+# Start monitoring
+./scripts/test-reconnection.sh
+
+# In another terminal, trigger multiple failovers
+./scripts/trigger-failover.sh
+sleep 120  # Wait for recovery
+./scripts/trigger-failover.sh
+sleep 120
+./scripts/trigger-failover.sh
+```
+
+Verify that:
+- Each failover is handled correctly
+- Failure count increments consistently
+- No connection pool exhaustion occurs
+- Application remains stable
+
+#### Scenario 3: API Testing During Failover
+
+```bash
+# Port forward
+kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+
+# Get current database info
+curl http://localhost:8080/api/db-info
+
+# Get monitoring statistics
+curl http://localhost:8080/api/monitor-stats
+
+# Test read operations
+curl http://localhost:8080/api/read-test
+
+# Test write operations
+curl -X POST "http://localhost:8080/api/write-test?message=Test"
+
+# Trigger failover and repeat API calls
+./scripts/trigger-failover.sh
+```
+
+## Interpreting Results
+
+### Successful Failover Behavior
+
+✅ **Good indicators:**
+- Connection loss detected within 5-10 seconds
+- Application reconnects within 10-20 seconds
+- Failure count increments by exactly 1
+- No cascading failures or connection pool exhaustion
+- Application switches to new primary automatically
+
+### Problematic Behavior
+
+❌ **Warning signs:**
+- Connection loss not detected (monitoring shows false positives)
+- Reconnection takes > 30 seconds
+- Multiple failure increments for single failover
+- Connection pool exhaustion errors
+- Application requires manual restart
+
+### Configuration Tuning
+
+If results are not optimal, consider tuning:
+
+**For faster detection:**
+```yaml
+# spring-app/src/main/resources/application.yml
+spring:
+  datasource:
+    hikari:
+      validation-timeout: 3000  # Reduce from 5000
+      connection-timeout: 8000  # Reduce from 10000
+```
+
+**For better stability:**
+```yaml
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 20     # Increase from 10
+      max-lifetime: 1800000     # Increase to 30 minutes
+```
+
+## Cleanup
+
+When testing is complete:
+
+```bash
+# Remove all deployed components
+helmfile destroy
+
+# Optional: Remove CRDs (WARNING: affects all pgskipper instances)
+kubectl delete crd patronicores.qubership.org patroniservices.qubership.org
+```
+
+## Troubleshooting
+
+### Issue: Application doesn't reconnect after failover
+
+**Check:**
+1. JDBC URL includes all PostgreSQL hosts:
+   ```bash
+   kubectl get configmap postgresql-failover-test-config -o yaml
+   ```
+
+2. Connection pool settings:
+   ```bash
+   curl http://localhost:8080/api/pool-info
+   ```
+
+3. PostgreSQL service endpoints:
+   ```bash
+   kubectl get endpoints -n postgres
+   ```
+
+### Issue: Slow failover (> 2 minutes)
+
+**Check:**
+1. Patroni configuration (TTL, loop wait times)
+2. Resource constraints on PostgreSQL pods
+3. Network latency between pods
+
+### Issue: Cannot access monitoring
+
+**Check:**
+1. Application pods are running:
+   ```bash
+   kubectl get pods -n default -l app.kubernetes.io/name=postgresql-failover-test
+   ```
+
+2. Port forward is active:
+   ```bash
+   kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+   ```
+
+## Next Steps
+
+After successful testing:
+
+1. **Document findings** - Record reconnection times and failure patterns
+2. **Optimize configuration** - Apply learnings to production settings
+3. **Implement monitoring** - Add Prometheus/Grafana for production observability
+4. **Create runbooks** - Document failover procedures for operations team
+5. **Test in staging** - Validate configuration in pre-production environment
+
+## Known Issues with pgskipper-operator
+
+**IMPORTANT:** This project **only supports pgskipper-operator (netcracker/pgskipper-operator)** for PostgreSQL deployment. Alternative PostgreSQL operators or Helm charts are not an option for this testing framework.
+
+### Issue 1: YAML Template Rendering Error (Line 111 in cr.yaml)
+
+**Error Message:**
+```
+Error: YAML parse error on patroni-core/templates/cr.yaml: error converting YAML to JSON:
+yaml: line 111: found character that cannot start any token
+```
+
+**Root Cause:**
+The `patroni-core` Helm chart template at `pgskipper-operator/charts/patroni-core/templates/cr.yaml` (lines 111-114) uses improper YAML indentation:
+
+```yaml
+  {{ else }}
+      limits:
+{{ toYaml .Values.patroni.resources.limits | indent 8}}
+      requests:
+{{ toYaml .Values.patroni.resources.requests | indent 8}}
+  {{ end }}
+```
+
+**Fix Applied:**
+Modified the template to use `nindent` instead of `indent` for proper YAML formatting:
+
+```yaml
+  {{- else }}
+      limits: {{- toYaml .Values.patroni.resources.limits | nindent 8 }}
+      requests: {{- toYaml .Values.patroni.resources.requests | nindent 8 }}
+  {{- end }}
+```
+
+**File:** `pgskipper-operator/charts/patroni-core/templates/cr.yaml:111-114`
+
+**Status:** ✅ FIXED - Template patch applied locally
+
+---
+
+### Issue 2: Operator Nil Pointer Dereference
+
+**Error Message:**
+```
+2025-10-06T13:55:52Z ERROR Observed a panic {"controller": "patronicore",
+"panic": "runtime error: invalid memory address or nil pointer dereference"}
+```
+
+**Root Cause:**
+The patroni-core-operator crashes with a nil pointer dereference at `pkg/reconciler/patroni.go:503` in `processPatroniStatefulset()` when trying to reconcile the PatroniCore custom resource.
+
+The operator attempts to access fields from the PatroniServices CR that haven't been populated yet, causing a race condition between the two operators.
+
+**Error Location:** `/workspace/pkg/reconciler/patroni.go:503`
+
+**Symptoms:**
+- Both `patroni-core` and `patroni-services` Helm releases deploy successfully
+- PatroniCore and PatroniServices custom resources are created
+- patroni-core-operator pod is running but continuously crashes during reconciliation
+- No PostgreSQL StatefulSet pods are created
+- Operator logs show: `PatroniCr: &{{ } {      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil>...}`
+
+**Attempted Solutions:**
+1. ✅ Added all required fields from default values.yaml to simple configuration
+2. ✅ Ensured `patroni.clusterName` matches between patroni-core and patroni-services
+3. ✅ Added missing `pgBackRest.dockerImage` field
+4. ❌ Operator still crashes with nil pointer error
+
+**Current Status:** ⚠️ BLOCKED - This appears to be a bug in the pgskipper-operator code itself
+
+**Workaround Needed:**
+The operator may require:
+- Additional undocumented required fields in the CRs
+- A specific deployment order or timing
+- Different configuration approach than documented
+- Bug fix in the upstream operator code
+
+### Issue 2: OrbStack Dual-Stack IPv6/IPv4 Incompatibility
+
+**Environment:** OrbStack Kubernetes (macOS)
+
+**Symptoms:**
+- PostgreSQL pods crash immediately after startup with: `socket.gaierror: [Errno -2] Name or service not known`
+- Patroni REST API fails to bind to listen address
+- Pod logs show: `listen: fd07:b51a:cc66:a::17f 192.168.194.10:8008` (IPv6 and IPv4 concatenated with space)
+- Both `pgBackRest` sidecar image pull fails (requires authentication)
+- `backup-daemon` fails with `runAsNonRoot` security context error
+
+**Root Cause:**
+OrbStack's Kubernetes runs in dual-stack mode (PreferDualStack) by default, which causes `status.podIP` to contain both IPv6 and IPv4 addresses separated by space (e.g., "fd07:b51a:cc66:a::17f 192.168.194.10"). The pgskipper-operator's Patroni image startup script uses `POD_IP` environment variable (populated from `status.podIP`) to set `LISTEN_ADDR`, which is then used for Patroni's REST API bind address. Python's `socket.getaddrinfo()` cannot parse this format, causing the crash.
+
+**Attempted Solutions:**
+1. ❌ Patch StatefulSet to use `status.podIPs[0].ip` - Not supported by Kubernetes fieldPath
+2. ❌ Disable IPv6 in OrbStack - No configuration option available
+3. ❌ Modify operator code - Would require maintaining a fork
+
+**Current Status:** ⚠️ BLOCKED on OrbStack - Works on other Kubernetes distributions
+
+**Recommended Solution:**
+Use a different Kubernetes distribution that either:
+- Runs in single-stack IPv4 mode (e.g., kind, minikube, k3d)
+- Correctly populates `status.podIP` with only the primary IP
+
+**Alternative Workarounds:**
+1. Build custom Patroni image with modified entrypoint to extract only IPv4 from POD_IP
+2. Use Kubernetes mutating webhook to inject an init container that sets LISTEN_ADDR properly
+3. Submit PR to pgskipper-operator to handle dual-stack scenarios
+
+## Additional Resources
+
+- [README.md](README.md) - Comprehensive project documentation
+- [HikariCP Configuration Guide](https://github.com/brettwooldridge/HikariCP)
+- [PostgreSQL JDBC Failover](https://jdbc.postgresql.org/documentation/use/#connection-fail-over)
+- [Patroni Documentation](https://patroni.readthedocs.io/)
+- [pgskipper-operator](https://github.com/Netcracker/pgskipper-operator) - **Required PostgreSQL operator for this project**

--- a/tests/examples/spring-boot-failover-test/docs/ORCHESTRATION_TOOL.md
+++ b/tests/examples/spring-boot-failover-test/docs/ORCHESTRATION_TOOL.md
@@ -1,0 +1,224 @@
+# Orchestration Tool Selection
+
+## Overview
+
+This document explains why Helmfile was chosen as the orchestration tool for this PostgreSQL failover test project and evaluates alternative tools.
+
+## Project Context
+
+This is an **ephemeral test infrastructure** project, not a production deployment system. Key characteristics:
+
+- **Lifecycle**: Create → Test → Destroy (ephemeral)
+- **Execution context**: Local developer machine
+- **State management**: Transient (no long-term state needed)
+- **Orchestration needs**: Multi-component with strict ordering
+- **Customization**: Environment-specific (OrbStack vs Rancher vs cloud)
+
+### User Workflow Pattern
+
+```bash
+# Setup test environment
+USE_LOCAL_IMAGES=true helmfile -e orbstack sync
+
+# Run tests
+./scripts/trigger-failover.sh
+
+# Cleanup
+helmfile destroy
+```
+
+## Critical Requirements
+
+1. **Local execution** - No cluster-based controllers needed
+2. **Conditional builds** - Based on env vars (USE_LOCAL_IMAGES)
+3. **Docker context switching** - OrbStack vs Rancher vs default
+4. **Storage auto-configuration** - Before deployment
+5. **Strict ordering** - storage → patroni-core → wait → patroni-services → wait → app
+6. **Rich validation/status reporting** - Pre/post-deployment hooks
+7. **Environment-specific overrides** - storageClass, dockerContext
+8. **One-command deployment and teardown**
+
+## Tool Comparison
+
+### 1. Helmfile (Current) - 95/100 ✅ RECOMMENDED
+
+**Why it's the right choice:**
+- ✅ Purpose-built for multi-Helm-release orchestration
+- ✅ Environment configs are first-class (default.yaml, orbstack.yaml, rancher.yaml)
+- ✅ Local execution with pre/post-sync hooks
+- ✅ One-command workflows (`helmfile sync`, `helmfile destroy`)
+- ✅ Helm release state tracking automatic (upgrade vs install)
+- ✅ Dependency management via `needs:` enforces strict ordering
+
+**Minor weaknesses:**
+- Bash hooks verbose (inherent to complex orchestration, not a tool issue)
+
+**Verdict:** ✅ Keep Helmfile - architecturally correct choice
+
+---
+
+### 2. Tilt - 85/100 🟡 VIABLE ALTERNATIVE
+
+**What it offers:**
+- ✅ Built specifically for local Kubernetes development
+- ✅ Excellent build integration (better than Helmfile)
+- ✅ Resource dependency graph native
+- ✅ Live updates, file watching, port-forwarding built-in
+
+**Why it's overengineered for this use case:**
+- ❌ Designed for continuous development (file watching unused)
+- ❌ No native environment concept (need separate Tiltfiles)
+- ❌ Storage validation requires `local_resource()` workarounds
+- ❌ You deploy once, not iteratively develop
+
+**Migration effort:** Medium (~2-3 days)
+**Value:** Marginal (10-15% better build UX, but loses environment elegance)
+
+**When to consider:**
+- Users frequently rebuild operator images during development
+- Build caching/optimization becomes important
+- Live update features would be valuable
+
+---
+
+### 3. Taskfile (Task) - 75/100 🟡 SIMPLER BUT LESS POWERFUL
+
+**Strengths:**
+- ✅ Clean, readable YAML syntax
+- ✅ Excellent for script-heavy workflows
+- ✅ Cross-platform (better than Makefile)
+- ✅ Simple dependency management (`deps:`)
+
+**Critical gaps:**
+- ❌ No Helm release state tracking (manual `--install` vs `--upgrade` logic)
+- ❌ Environment configs would be `.env` files (less elegant)
+- ❌ Manual Kubernetes waiting (`kubectl wait` in every task)
+
+**Example structure:**
+```yaml
+tasks:
+  sync:
+    deps: [storage, build, deploy-core, deploy-services, deploy-app]
+
+  storage:
+    cmds: [./scripts/configure-storage.sh --auto]
+
+  build:
+    cmds: [make docker-build]
+    status: ["test $USE_LOCAL_IMAGES != 'true'"]
+```
+
+**Migration effort:** Medium (~1-2 days)
+**Value:** Debatable (simpler but more manual)
+
+**When to consider:**
+- Team prefers explicit task scripts over Helmfile abstractions
+- Helm release state tracking isn't critical
+- Comfortable with more manual kubectl commands
+
+---
+
+### 4. ArgoCD / FluxCD - 20/100 ❌ WRONG TOOL CATEGORY
+
+**Fatal architectural mismatches:**
+- ❌ Cluster-based controllers (requires installation, adds complexity)
+- ❌ GitOps workflow (commit → detect → reconcile adds latency)
+- ❌ **Cannot trigger local Docker builds** (dealbreaker)
+- ❌ Cannot switch Docker contexts (OrbStack vs Rancher)
+- ❌ Storage validation runs locally (ArgoCD runs in-cluster)
+- ❌ Teardown requires deleting Applications, not simple `destroy`
+
+**Verdict:** GitOps tools for ephemeral test infrastructure is an anti-pattern
+
+**Why they're wrong:**
+- These are production continuous delivery systems
+- Require git commits for changes (adds friction)
+- Controllers run in-cluster (not local)
+- Designed for drift detection/reconciliation (not needed)
+- Massive complexity increase for zero benefit
+
+---
+
+### 5. Helm Umbrella Chart + Scripts - 60/100 🟡 AWKWARD SPLIT
+
+**What it would look like:**
+```bash
+setup.sh  # build logic, storage config
+  → helm install test-env ./umbrella-chart -f values-orbstack.yaml
+```
+
+**Problems:**
+- ❌ Splits orchestration (setup.sh + Helm hooks)
+- ❌ Helm hooks run in-cluster (can't do local builds)
+- ❌ Sub-chart dependencies loose (no clean waiting)
+- ❌ Defeats "one command" goal
+
+---
+
+### 6. Skaffold - 75/100 🟡 BETTER FOR ACTIVE DEVELOPMENT
+
+**What it offers:**
+- ✅ Unified build config (Maven/buildpacks and Docker in one file)
+- ✅ File watching and auto-rebuild (`skaffold dev`)
+- ✅ Less verbose build orchestration
+- ✅ Better dev workflow (port-forwarding, log tailing, hot reload)
+- ✅ Helm integration with dependencies
+
+**Why it's not ideal for this use case:**
+- ❌ Validation hooks less elegant (require external scripts or Jobs)
+- ❌ Environment management less clean than helmfile
+- ❌ One-time deployment pattern (`helmfile sync`) vs continuous dev (`skaffold dev`)
+- ❌ File watching features unused
+
+**Verbosity comparison:**
+- Helmfile: ~237 lines (helmfile.yaml.gotmpl + env files)
+- Skaffold: ~150-180 lines (but validation logic moves to external scripts)
+- **Net reduction: ~5-10%** (minimal benefit)
+
+**When to consider:**
+- If users frequently modify Spring Boot code during testing
+- If you add a continuous development workflow
+- If you eliminate most validation hooks
+
+---
+
+## Strategic Recommendations
+
+### Option 1: Keep Helmfile ✅ **RECOMMENDED**
+- Zero migration cost
+- Architecturally correct for ephemeral test infrastructure
+- Bash verbosity is symptom of complex requirements, not poor tool choice
+- Environment management superior to alternatives
+
+### Option 2: Migrate to Tilt (Only if build UX critical)
+**ROI:** Marginal (~10% improvement in build experience)
+
+### Option 3: Simplify with Taskfile (If team prefers explicit over magic)
+**ROI:** Debatable (trades elegance for explicitness)
+
+## Final Verdict
+
+**Keep Helmfile.** The architecture is well-designed for its purpose. The alternatives either:
+- Add massive complexity without benefits (ArgoCD/FluxCD)
+- Trade Helm-specific features for marginal gains (Taskfile)
+- Provide features you don't need (Tilt's continuous dev, Skaffold's file watching)
+
+The bash hook verbosity is inherent to orchestration requirements (storage config, build logic, validation), not a symptom of wrong tool choice.
+
+## Design Pattern Validation
+
+✅ **Ephemeral test infrastructure pattern correctly implemented**
+✅ **Local execution model appropriate for developer tooling**
+✅ **Multi-component orchestration with strict dependencies well-handled**
+✅ **Environment variability (OrbStack/Rancher/cloud) properly abstracted**
+✅ **Build integration (conditional local images) architecturally sound**
+
+**No overengineering detected.** Complexity comes from requirements (3-tier orchestration, validation, builds), not tool choice.
+
+## References
+
+- [Helmfile Documentation](https://helmfile.readthedocs.io/)
+- [Tilt Documentation](https://docs.tilt.dev/)
+- [Task Documentation](https://taskfile.dev/)
+- [ArgoCD Documentation](https://argo-cd.readthedocs.io/)
+- [Skaffold Documentation](https://skaffold.dev/)

--- a/tests/examples/spring-boot-failover-test/docs/TROUBLESHOOTING.md
+++ b/tests/examples/spring-boot-failover-test/docs/TROUBLESHOOTING.md
@@ -1,0 +1,394 @@
+# Troubleshooting Guide
+
+**Location:** `tests/examples/spring-boot-failover-test/`
+
+This guide covers common issues and their solutions when working with the PostgreSQL failover test example.
+
+## Table of Contents
+- [Storage Configuration Issues](#storage-configuration-issues)
+- [pgskipper-operator Issues](#pgskipper-operator-issues)
+- [Build Issues](#build-issues)
+- [Deployment Issues](#deployment-issues)
+- [Failover Testing Issues](#failover-testing-issues)
+
+## Storage Configuration Issues
+
+### Problem: No Default StorageClass
+
+**Symptoms:**
+- PVCs stuck in `Pending` state
+- Error: `no persistent volumes available`
+
+**Solution:**
+
+Check available storage classes:
+```bash
+kubectl get storageclass
+```
+
+If no default storage class exists, configure one:
+```bash
+./scripts/configure-storage.sh
+```
+
+Or set manually for your cluster type:
+
+**Docker Desktop / OrbStack:**
+```bash
+kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+**Minikube:**
+```bash
+kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+**Kind:**
+```bash
+kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+### Problem: PVC Stuck in Pending
+
+**Symptoms:**
+- PostgreSQL pods in `Pending` state
+- PVCs show `Pending` status
+
+**Check:**
+```bash
+kubectl get pvc -n postgres
+kubectl describe pvc <pvc-name> -n postgres
+```
+
+**Solutions:**
+1. Ensure storage class exists and is default
+2. Check if cluster has available storage
+3. Verify storage provisioner is running
+
+---
+
+## pgskipper-operator Issues
+
+### Issue: Operator Nil Pointer Dereference
+
+**Error Message:**
+```
+ERROR Observed a panic {"controller": "patronicore",
+"panic": "runtime error: invalid memory address or nil pointer dereference"}
+```
+
+**Root Cause:**
+The patroni-core-operator crashes with a nil pointer dereference when trying to reconcile the PatroniCore custom resource.
+
+**Status:** Historical issue - check operator logs to see if this still occurs with current version.
+
+**Workaround:**
+Ensure all required fields are set in patroni-core-values.yaml and patroni-services-values.yaml.
+
+### Issue: OrbStack Dual-Stack IPv6/IPv4 Incompatibility
+
+**Environment:** OrbStack Kubernetes (macOS)
+
+**Symptoms:**
+- PostgreSQL pods crash immediately after startup
+- Error: `socket.gaierror: [Errno -2] Name or service not known`
+- Patroni REST API fails to bind
+- Pod logs show IPv6 and IPv4 concatenated: `fd07:b51a:cc66:a::17f 192.168.194.10:8008`
+
+**Root Cause:**
+OrbStack's Kubernetes runs in dual-stack mode, causing `status.podIP` to contain both IPv6 and IPv4 addresses separated by space. The pgskipper-operator's Patroni image uses this for `LISTEN_ADDR`, which Python's socket library cannot parse.
+
+**Status:** ✅ FIXED - listen_addr and connect_address patches have been applied to the operator
+
+**Solution (if using local build):**
+```bash
+# Deploy with locally-built fixed operator
+helmfile sync -e local
+```
+
+**Alternative Workaround:**
+Use a different Kubernetes distribution:
+- kind
+- minikube
+- k3d
+- Docker Desktop (Linux mode)
+
+---
+
+## Build Issues
+
+### Problem: Buildpacks Build Fails
+
+**Symptoms:**
+- Error during `./scripts/build.sh`
+- Pack CLI not found or fails
+
+**Solutions:**
+
+1. **Install Pack CLI:**
+```bash
+# macOS
+brew install buildpacks/tap/pack
+
+# Linux
+(curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.33.2/pack-v0.33.2-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+
+# Windows
+choco install pack
+```
+
+2. **Use Maven Docker build instead:**
+```bash
+cd spring-app
+mvn spring-boot:build-image
+```
+
+### Problem: Docker Build Fails
+
+**Symptoms:**
+- Docker daemon not running
+- Permission denied errors
+
+**Solutions:**
+
+1. **Start Docker:**
+```bash
+# Check Docker status
+docker info
+
+# Start Docker Desktop (macOS/Windows)
+open -a Docker
+```
+
+2. **Fix permissions (Linux):**
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+### Problem: Maven Build Fails
+
+**Symptoms:**
+- Dependency resolution errors
+- Java version mismatch
+
+**Solutions:**
+
+1. **Check Java version:**
+```bash
+java -version
+# Should be 17 or higher
+```
+
+2. **Clear Maven cache:**
+```bash
+rm -rf ~/.m2/repository
+mvn clean install
+```
+
+---
+
+## Deployment Issues
+
+### Problem: Patroni Pods Crash on Startup
+
+**Symptoms:**
+- Pods in `CrashLoopBackOff`
+- Patroni REST API binding errors
+
+**Check Logs:**
+```bash
+kubectl logs -n postgres postgres-cluster-0
+```
+
+**Solutions:**
+
+1. **For IPv6/IPv4 issues:** Use local operator build (see pgskipper-operator Issues above)
+
+2. **For resource constraints:**
+```bash
+# Check node resources
+kubectl top nodes
+kubectl describe node
+
+# Reduce resource requests in patroni-core-simple.yaml
+```
+
+3. **For storage issues:** See Storage Configuration Issues above
+
+### Problem: Application Cannot Connect to Database
+
+**Symptoms:**
+- Application pods running but can't connect
+- Connection timeout errors
+
+**Check:**
+
+1. **PostgreSQL service exists:**
+```bash
+kubectl get svc -n postgres
+```
+
+2. **PostgreSQL pods are running:**
+```bash
+kubectl get pods -n postgres -l app=postgres
+```
+
+3. **Check application logs:**
+```bash
+kubectl logs -n default -l app.kubernetes.io/name=postgresql-failover-test
+```
+
+4. **Verify JDBC URL:**
+```bash
+kubectl get configmap postgresql-failover-test-config -o yaml
+```
+
+**Solutions:**
+
+1. **Wait for PostgreSQL to be fully ready:**
+```bash
+kubectl wait --for=condition=ready --timeout=600s pods -l app=postgres -n postgres
+```
+
+2. **Check connection string format:**
+Should be: `jdbc:postgresql://postgres-cluster-0.postgres:5432,postgres-cluster-1.postgres:5432/postgres`
+
+---
+
+## Failover Testing Issues
+
+### Problem: Application Doesn't Reconnect After Failover
+
+**Symptoms:**
+- Connection lost detected
+- Application stays disconnected after new primary elected
+- Manual restart required
+
+**Check:**
+
+1. **JDBC URL includes all hosts:**
+```bash
+curl http://localhost:8080/api/db-info
+```
+
+2. **Connection pool settings:**
+```bash
+curl http://localhost:8080/api/pool-info
+```
+
+**Solutions:**
+
+1. **Tune HikariCP settings** in `spring-app/src/main/resources/application.yml`:
+```yaml
+spring:
+  datasource:
+    hikari:
+      connection-timeout: 10000
+      validation-timeout: 5000
+      max-lifetime: 1800000
+      keepalive-time: 30000
+```
+
+2. **Verify multi-host URL:**
+Ensure JDBC URL contains all PostgreSQL pods
+
+3. **Check for connection pool exhaustion:**
+```bash
+kubectl logs -n default -l app.kubernetes.io/name=postgresql-failover-test | grep -i "timeout\|exhausted"
+```
+
+### Problem: Slow Failover (> 2 minutes)
+
+**Symptoms:**
+- Long detection time
+- Slow Patroni promotion
+- Extended downtime
+
+**Check:**
+
+1. **Patroni configuration:**
+```bash
+kubectl exec -n postgres postgres-cluster-0 -- patronictl list
+```
+
+2. **Resource constraints:**
+```bash
+kubectl top pods -n postgres
+```
+
+**Solutions:**
+
+1. **Tune Patroni timing** in patroni-core-simple.yaml:
+```yaml
+patroniParams:
+  - "primary_start_timeout: 30"
+  - "retry_timeout: 600"
+  - "ttl: 30"
+  - "loop_wait: 10"
+```
+
+2. **Increase resources** if constrained:
+```yaml
+patroni:
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+```
+
+3. **Reduce validation timeout** in HikariCP
+
+### Problem: Cannot Access Monitoring API
+
+**Symptoms:**
+- Connection refused on port 8080
+- `kubectl port-forward` fails
+
+**Solutions:**
+
+1. **Ensure pods are running:**
+```bash
+kubectl get pods -n default -l app.kubernetes.io/name=postgresql-failover-test
+```
+
+2. **Start port forward:**
+```bash
+kubectl port-forward -n default svc/postgresql-failover-test 8080:8080
+```
+
+3. **Check for port conflicts:**
+```bash
+# Kill process using port 8080
+lsof -ti:8080 | xargs kill -9
+```
+
+---
+
+## Additional Help
+
+If you encounter issues not covered here:
+
+1. Check operator logs:
+```bash
+kubectl logs -n postgres -l app.kubernetes.io/name=patroni-core-operator
+kubectl logs -n postgres -l app.kubernetes.io/name=patroni-services-operator
+```
+
+2. Check PostgreSQL logs:
+```bash
+kubectl logs -n postgres postgres-cluster-0
+```
+
+3. Check application logs:
+```bash
+kubectl logs -n default -l app.kubernetes.io/name=postgresql-failover-test -f
+```
+
+4. Verify Kubernetes events:
+```bash
+kubectl get events -n postgres --sort-by='.lastTimestamp'
+kubectl get events -n default --sort-by='.lastTimestamp'
+```
+
+5. Consult the main [pgskipper-operator documentation](../../../README.md)

--- a/tests/examples/spring-boot-failover-test/environments.yaml
+++ b/tests/examples/spring-boot-failover-test/environments.yaml
@@ -1,0 +1,18 @@
+# Helmfile Environments Configuration
+#
+# Define environment-specific settings for different deployment contexts
+# Usage: helmfile -e <environment> sync
+
+environments:
+  default:
+    values:
+      - environments/default.yaml
+  local:
+    values:
+      - environments/local.yaml
+  minikube:
+    values:
+      - environments/minikube.yaml
+  kind:
+    values:
+      - environments/kind.yaml

--- a/tests/examples/spring-boot-failover-test/environments/default.yaml
+++ b/tests/examples/spring-boot-failover-test/environments/default.yaml
@@ -1,0 +1,5 @@
+# Default environment - for cloud/remote Kubernetes clusters
+# This is a generic configuration for external clusters
+
+storageClass: standard
+dockerContext: default

--- a/tests/examples/spring-boot-failover-test/environments/orbstack.yaml
+++ b/tests/examples/spring-boot-failover-test/environments/orbstack.yaml
@@ -1,0 +1,5 @@
+# OrbStack environment - for local development with OrbStack
+# OrbStack provides a lightweight Kubernetes cluster on macOS
+
+storageClass: local-path
+dockerContext: orbstack

--- a/tests/examples/spring-boot-failover-test/environments/rancher.yaml
+++ b/tests/examples/spring-boot-failover-test/environments/rancher.yaml
@@ -1,0 +1,5 @@
+# Rancher Desktop environment - for local development with Rancher Desktop
+# Rancher Desktop provides a lightweight Kubernetes cluster with k3s
+
+storageClass: local-path
+dockerContext: rancher-desktop

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-minimal.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-minimal.yaml
@@ -1,0 +1,7 @@
+# Absolute minimal values for patroni-core
+postgresUser: postgres
+postgresPassword: postgres
+replicatorPassword: replicator
+
+global:
+  cloudIntegrationEnabled: false

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-simple.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-simple.yaml
@@ -1,0 +1,79 @@
+# Minimal working values for patroni-core
+postgresUser: postgres
+postgresPassword: postgres
+replicatorPassword: replicator
+
+# Disable cloud integration for local testing
+global:
+  cloudIntegrationEnabled: false
+
+# Service account
+serviceAccount:
+  create: true
+  name: "patroni-sa"
+
+# Vault registration (disabled)
+vaultRegistration:
+  dockerImage: banzaicloud/vault-env:1.5.0
+  enabled: false
+  dbEngine:
+    enabled: false
+
+# TLS configuration (disabled for local testing)
+tls:
+  enabled: false
+  certificateSecretName: pg-cert
+
+# Configure Patroni cluster
+patroni:
+  install: true
+  clusterName: patroni
+  replicas: 2
+  dockerImage: ghcr.io/netcracker/pgskipper-patroni-16:main
+  dcs:
+    type: kubernetes
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  postgreSQLParams:
+    - "password_encryption: md5"
+    - "max_connections: 200"
+    - "shared_preload_libraries: pg_stat_statements, pg_hint_plan, pg_cron"
+    - "wal_level: logical"
+  patroniParams:
+    - "failsafe_mode: true"
+    - "primary_start_timeout: 30"
+    - "retry_timeout: 600"
+  storage:
+    type: provisioned
+    size: 5Gi
+    storageClass: local-path
+    enableShmVolume: true
+  majorUpgrade:
+    enabled: false
+    dockerUpgradeImage: ghcr.io/netcracker/qubership-pgskipper-upgrade:main
+
+# Operator configuration
+operator:
+  image: ghcr.io/netcracker/pgskipper-operator:main
+  waitTimeout: 10
+  resources:
+    limits:
+      cpu: 50m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+# Backup storage disabled - requires authentication to pull image
+# pgBackRest:
+#   dockerImage: "ghcr.io/netcracker/pgbackrest-sidecar:main"
+#   repoType: "pv"
+#   repoPath: "/var/lib/pgbackrest"
+#   diffSchedule: "0 0/1 * * *"
+#   incrSchedule: "0 0/1 * * *"
+#   backupFromStandby: false

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-values.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-core-values.yaml
@@ -1,0 +1,114 @@
+# Custom values for patroni-core Helm chart
+# This configures the Patroni Core operator for PostgreSQL HA
+
+# Namespace configuration
+namespace: postgres
+
+# Operator configuration
+operator:
+  replicas: 1
+  image:
+    repository: netcracker/patroni-core-operator
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# PostgreSQL cluster configuration
+patroniCore:
+  enabled: true
+  name: postgres-cluster
+
+  # PostgreSQL version
+  postgresVersion: "15"
+
+  # Cluster topology
+  topology:
+    # Number of PostgreSQL instances (1 primary + 2 replicas)
+    replicas: 3
+
+  # Storage configuration
+  storage:
+    # Storage class for persistent volumes
+    # Update this based on your Kubernetes cluster
+    storageClassName: "standard"
+    size: "10Gi"
+    accessMode: ReadWriteOnce
+
+  # Resource allocation for PostgreSQL pods
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+  # Patroni configuration for HA
+  patroni:
+    # DCS (Distributed Configuration Store) settings
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576  # 1MB
+
+    # PostgreSQL parameters
+    postgresql:
+      parameters:
+        max_connections: 100
+        shared_buffers: 512MB
+        effective_cache_size: 1536MB
+        maintenance_work_mem: 128MB
+        checkpoint_completion_target: 0.9
+        wal_buffers: 16MB
+        default_statistics_target: 100
+        random_page_cost: 1.1
+        effective_io_concurrency: 200
+        work_mem: 5242kB
+        min_wal_size: 1GB
+        max_wal_size: 4GB
+        # Replication settings
+        hot_standby: "on"
+        wal_level: replica
+        max_wal_senders: 10
+        max_replication_slots: 10
+
+  # pgBackRest configuration (optional, for backups)
+  backup:
+    enabled: false
+
+# Service configuration
+service:
+  # Service type for external access
+  type: ClusterIP
+  port: 5432
+  # Create separate services for primary and replica
+  separateServices: true
+
+# Security
+security:
+  # Enable TLS
+  tls:
+    enabled: false
+
+  # PostgreSQL users
+  users:
+    - name: postgres
+      password: postgres  # CHANGE THIS IN PRODUCTION!
+      superuser: true
+    - name: app_user
+      password: app_password  # CHANGE THIS IN PRODUCTION!
+      databases:
+        - testdb
+
+# Monitoring (optional)
+monitoring:
+  enabled: false
+  prometheus:
+    enabled: false

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-minimal.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-minimal.yaml
@@ -1,0 +1,7 @@
+# Absolute minimal values for patroni-services
+postgresUser: postgres
+postgresPassword: postgres
+replicatorPassword: replicator
+
+global:
+  cloudIntegrationEnabled: false

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-simple.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-simple.yaml
@@ -1,0 +1,88 @@
+# Minimal working values for patroni-services
+postgresUser: postgres
+postgresPassword: postgres
+replicatorPassword: replicator
+
+global:
+  cloudIntegrationEnabled: false
+
+serviceAccount:
+  create: true
+  name: "postgres-sa"
+
+# Vault registration (disabled)
+vaultRegistration:
+  dockerImage: banzaicloud/vault-env:1.5.0
+  enabled: false
+  dbEngine:
+    enabled: false
+
+# TLS configuration (disabled)
+tls:
+  enabled: false
+  certificateSecretName: pg-cert
+
+# Patroni cluster name (must match patroni-core)
+patroni:
+  clusterName: patroni
+
+# Operator configuration
+operator:
+  image: ghcr.io/netcracker/pgskipper-operator:main
+  waitTimeout: 10
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
+# Metric collector
+metricCollector:
+  install: true
+  dockerImage: ghcr.io/netcracker/pgskipper-monitoring-agent:main
+  databaseConnectionLimits: 250
+  resources:
+    limits:
+      cpu: 300m
+      memory: 256Mi
+    requests:
+      cpu: 150m
+      memory: 170Mi
+  userPassword: "p@ssWOrD1"
+  collectionInterval: 60
+  scrapeTimeout: 20
+  telegrafPluginTimeout: 60
+  ocExecTimeout: 10
+  metricsProfile: prod
+  prometheusMonitoring: false
+  applyGrafanaDashboard: false
+
+# Backup daemon - disabled due to security context incompatibility
+backupDaemon:
+  install: false
+  dockerImage: ghcr.io/netcracker/pgskipper-backup-daemon:main
+  compressionLevel: 5
+  walArchiving: false
+  backupSchedule: "0 0/7 * * *"
+  evictionPolicy: "7d/delete"
+  backupTimeout: 300
+  granularEviction: "3600"
+  encryption: false
+  retainArchiveSettings: false
+  allowPrefix: false
+  useEvictionPolicyFirst: false
+  evictionBinaryPolicy: "7d/delete"
+  archiveEvictionPolicy: "7d"
+  resources:
+    limits:
+      cpu: 450m
+      memory: 768Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  storage:
+    type: provisioned
+    size: 1Gi
+    storageClass: local-path

--- a/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-values.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/postgresql/patroni-services-values.yaml
@@ -1,0 +1,75 @@
+# Custom values for patroni-services Helm chart
+# This configures the Patroni Services for the PostgreSQL cluster
+
+# Namespace configuration
+namespace: postgres
+
+# Operator configuration
+operator:
+  replicas: 1
+  image:
+    repository: netcracker/patroni-services-operator
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# Service configuration for the PostgreSQL cluster
+patroniService:
+  enabled: true
+  name: postgres-service
+
+  # Reference to the PatroniCore cluster
+  clusterName: postgres-cluster
+
+  # Service type
+  serviceType: ClusterIP
+
+  # Connection pooling with PgBouncer (optional)
+  pgbouncer:
+    enabled: false
+    replicas: 2
+    poolMode: transaction
+    maxClientConnections: 100
+    defaultPoolSize: 25
+
+  # Load balancing configuration
+  loadBalancing:
+    enabled: true
+    # Route read queries to replicas
+    readOnlyService: true
+
+# Database initialization
+databases:
+  - name: testdb
+    owner: postgres
+    encoding: UTF8
+    lc_collate: en_US.UTF-8
+    lc_ctype: en_US.UTF-8
+    template: template0
+
+# Service endpoints
+services:
+  # Primary service (read-write)
+  primary:
+    name: postgres-primary
+    port: 5432
+    targetPort: 5432
+
+  # Replica service (read-only)
+  replica:
+    name: postgres-replica
+    port: 5432
+    targetPort: 5432
+
+  # Combined service (routes to primary for writes, replicas for reads)
+  combined:
+    name: postgres-service
+    port: 5432
+    targetPort: 5432

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/Chart.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: postgresql-failover-test
+description: Spring Boot application for testing PostgreSQL failover and reconnection
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - postgresql
+  - spring-boot
+  - failover
+  - high-availability
+maintainers:
+  - name: PostgreSQL Stability Testing

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/_helpers.tpl
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "postgresql-failover-test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "postgresql-failover-test.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgresql-failover-test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "postgresql-failover-test.labels" -}}
+helm.sh/chart: {{ include "postgresql-failover-test.chart" . }}
+{{ include "postgresql-failover-test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "postgresql-failover-test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgresql-failover-test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "postgresql-failover-test.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "postgresql-failover-test.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/configmap.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "postgresql-failover-test.fullname" . }}-config
+  labels:
+    {{- include "postgresql-failover-test.labels" . | nindent 4 }}
+data:
+  database-url: "jdbc:postgresql://{{ .Values.database.hosts }}/{{ .Values.database.name }}?{{ .Values.database.jdbcParams }}"

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/deployment.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postgresql-failover-test.fullname" . }}
+  labels:
+    {{- include "postgresql-failover-test.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "postgresql-failover-test.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "postgresql-failover-test.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "postgresql-failover-test.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: {{ .Values.springBoot.profile }}
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "postgresql-failover-test.fullname" . }}-config
+              key: database-url
+        - name: DATABASE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql-failover-test.fullname" . }}-secret
+              key: database-username
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql-failover-test.fullname" . }}-secret
+              key: database-password
+        - name: JAVA_OPTS
+          value: {{ .Values.springBoot.javaOpts }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/secret.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgresql-failover-test.fullname" . }}-secret
+  labels:
+    {{- include "postgresql-failover-test.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-username: {{ .Values.database.username }}
+  database-password: {{ .Values.database.password }}

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/service.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgresql-failover-test.fullname" . }}
+  labels:
+    {{- include "postgresql-failover-test.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "postgresql-failover-test.selectorLabels" . | nindent 4 }}

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/serviceaccount.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "postgresql-failover-test.serviceAccountName" . }}
+  labels:
+    {{- include "postgresql-failover-test.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/tests/examples/spring-boot-failover-test/helm-charts/spring-app/values.yaml
+++ b/tests/examples/spring-boot-failover-test/helm-charts/spring-app/values.yaml
@@ -1,0 +1,102 @@
+replicaCount: 2
+
+image:
+  repository: postgresql-failover-test
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: failover-test.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+# PostgreSQL connection configuration
+database:
+  # Multi-host connection string for failover
+  # Will be constructed from the pgskipper service endpoints
+  # Format: jdbc:postgresql://host1:5432,host2:5432,host3:5432/dbname?targetServerType=primary
+  hosts: "pg-patroni.postgres.svc.cluster.local:5432"
+  name: "postgres"
+  username: "postgres"
+  password: "postgres"
+  # Additional JDBC parameters
+  jdbcParams: ""
+  #jdbcParams: "targetServerType=primary&loadBalanceHosts=true&connectTimeout=10&socketTimeout=30&tcpKeepAlive=true"
+
+# Spring Boot application configuration
+springBoot:
+  profile: "production"
+  javaOpts: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+
+# Probes configuration
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/tests/examples/spring-boot-failover-test/helmfile.yaml.gotmpl
+++ b/tests/examples/spring-boot-failover-test/helmfile.yaml.gotmpl
@@ -1,0 +1,131 @@
+# PostgreSQL Failover Test - Helmfile Configuration
+#
+# Location: tests/examples/spring-boot-failover-test/
+# This example demonstrates PostgreSQL failover testing with Spring Boot
+#
+# This helmfile imports the pgskipper-operator from the root helmfile and adds:
+# - Spring Boot test application
+#
+# Usage:
+#   helmfile sync                      - Deploy with official images
+#   helmfile -e orbstack sync          - Deploy to OrbStack
+#   helmfile -e rancher sync           - Deploy to Rancher Desktop
+#   helmfile -e k3d-v4only sync        - Deploy to k3d with IPv4 only
+#
+# Environment Variables (optional):
+#   USE_LOCAL_IMAGES=true              - Build and use local operator images (passed to root helmfile)
+#   PGSKIPPER_IMAGE=<image>            - Override operator image (passed to root helmfile)
+#   PGSKIPPER_TAG=<tag>                - Override operator tag (passed to root helmfile)
+#   APP_IMAGE_TAG=<tag>                - Override Spring Boot app image tag (default: latest)
+#
+# Examples:
+#   USE_LOCAL_IMAGES=true helmfile -e orbstack sync  - Build local images for OrbStack
+#   PGSKIPPER_TAG=v1.2.3 helmfile sync               - Use specific version from ghcr.io
+#   APP_IMAGE_TAG=1.0.0 helmfile sync                - Build and deploy app with tag 1.0.0
+
+helmDefaults:
+  wait: true
+  timeout: 600
+  createNamespace: true
+  cleanupOnFail: true
+
+environments:
+  default:
+    values:
+      - environments/default.yaml
+  k3d-v4only:
+    values:
+      - environments/k3d-v4only.yaml
+  orbstack:
+    values:
+      - environments/orbstack.yaml
+  rancher:
+    values:
+      - environments/rancher.yaml
+
+# Import pgskipper-operator from root helmfile
+helmfiles:
+  - path: ../../../helmfile.yaml
+    # Inherit environment from this helmfile
+    selectors: []
+    values: []
+
+---
+
+{{ $namespace := env "NAMESPACE" | default "postgres" }}
+{{ $appNamespace := env "APP_NAMESPACE" | default "default" }}
+
+{{/* Spring Boot application image configuration */}}
+{{ $appImageTag := env "APP_IMAGE_TAG" | default "latest" }}
+
+releases:
+  #############################################################################
+  # Spring Boot Test Application
+  # Application that tests PostgreSQL failover behavior
+  #############################################################################
+  - name: failover-test
+    namespace: {{ $appNamespace }}
+    chart: ./helm-charts/spring-app
+    labels:
+      component: test-application
+      type: spring-boot
+    values:
+      - image:
+          tag: {{ $appImageTag }}
+    needs:
+      - {{ $namespace }}/patroni-services
+    hooks:
+      # Build Docker image before deployment
+      - events: ["presync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            # Switch to configured Docker context
+            DOCKER_CONTEXT="{{ .Values.dockerContext | default "default" }}"
+            CURRENT_CONTEXT=$(docker context show)
+            echo "Current Docker context: $CURRENT_CONTEXT"
+            echo "Target Docker context: $DOCKER_CONTEXT"
+
+            if [ "$CURRENT_CONTEXT" != "$DOCKER_CONTEXT" ]; then
+              echo "Switching to $DOCKER_CONTEXT context..."
+              docker context use "$DOCKER_CONTEXT"
+            fi
+
+            echo "Building Spring Boot application Docker image tag ..."
+            IMAGE_TAG="{{ $appImageTag }}" ./scripts/build.sh
+      # Wait for application to be ready
+      - events: ["postsync"]
+        showlogs: true
+        command: "bash"
+        args:
+          - "-c"
+          # language=bash
+          - |
+            echo "Waiting for application pods to be ready..."
+            kubectl wait --for=condition=ready --timeout=300s \
+              pods -l app.kubernetes.io/name=postgresql-failover-test -n {{ $appNamespace }}
+
+            echo "Application is ready!"
+
+            # Display status
+            echo ""
+            echo "====================================="
+            echo "Deployment Complete!"
+            echo "====================================="
+            echo ""
+            echo "PostgreSQL Cluster Status:"
+            kubectl get pods -n {{ $namespace }} -l app=postgres
+            echo ""
+            echo "Application Status:"
+            kubectl get pods -n {{ $appNamespace }} -l app.kubernetes.io/name=postgresql-failover-test
+            echo ""
+            echo "Services:"
+            kubectl get svc -n {{ $namespace }}
+            echo ""
+            echo "Next steps:"
+            echo "1. Check application logs: kubectl logs -f -n {{ $appNamespace }} -l app.kubernetes.io/name=postgresql-failover-test"
+            echo "2. Test failover: ./scripts/trigger-failover.sh"
+            echo "3. Monitor reconnection: ./scripts/test-reconnection.sh"

--- a/tests/examples/spring-boot-failover-test/scripts/build-operators.sh
+++ b/tests/examples/spring-boot-failover-test/scripts/build-operators.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Build custom pgskipper-operator images using Makefile
+#
+# This script builds Docker images for pgskipper-operator using the upstream Makefile.
+#
+# Usage:
+#   ./scripts/build-operators.sh [TAG]
+#
+# Arguments:
+#   TAG - Image tag to use (default: local)
+#
+# Examples:
+#   ./scripts/build-operators.sh           # Build with tag "local"
+#   ./scripts/build-operators.sh v1.2.3    # Build with tag "v1.2.3"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OPERATOR_DIR="$(cd "$EXAMPLE_ROOT/../../.." && pwd)"
+
+TAG="${1:-local}"
+IMAGE_NAME="${2:-pgskipper-operator}"
+
+echo "=========================================="
+echo "Building pgskipper-operator Images"
+echo "=========================================="
+echo ""
+echo "Tag: $TAG"
+echo "Image: $IMAGE_NAME:$TAG"
+echo "Operator directory: $OPERATOR_DIR"
+echo ""
+
+# Check if operator directory exists
+if [ ! -d "$OPERATOR_DIR" ]; then
+  echo "ERROR: pgskipper-operator directory not found at: $OPERATOR_DIR"
+  echo ""
+  echo "Expected pgskipper-operator root at:"
+  echo "  $OPERATOR_DIR"
+  echo "This script should be run from within the pgskipper-operator repository."
+  exit 1
+fi
+
+# Check if Makefile exists
+if [ ! -f "$OPERATOR_DIR/Makefile" ]; then
+  echo "ERROR: Makefile not found at: $OPERATOR_DIR/Makefile"
+  exit 1
+fi
+
+cd "$OPERATOR_DIR"
+
+echo "Building using Makefile..."
+TAG_ENV="$TAG" DOCKER_NAMES="$IMAGE_NAME:$TAG" make docker-build
+
+echo ""
+echo "=========================================="
+echo "Build Complete!"
+echo "=========================================="
+echo ""
+echo "Image built:"
+echo "  - $IMAGE_NAME:$TAG"
+echo ""
+echo "Next steps:"
+echo "  1. Deploy with local images:"
+echo "     helmfile -e orbstack sync"
+echo ""

--- a/tests/examples/spring-boot-failover-test/scripts/build.sh
+++ b/tests/examples/spring-boot-failover-test/scripts/build.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Spring Boot Application Build Script
+# Builds multi-architecture Docker images using Docker Buildx
+
+set -e
+
+# Configuration
+IMAGE_NAME="${IMAGE_NAME:-postgresql-failover-test}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+PUSH="${PUSH:-false}"
+
+echo "===================================="
+echo "Building Multi-Architecture Docker Image"
+echo "===================================="
+echo ""
+
+echo "Image: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "Platforms: ${PLATFORMS}"
+echo "Push: ${PUSH}"
+echo ""
+
+# Check if Docker is available
+command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed" >&2; exit 1; }
+
+# Navigate to spring-app directory
+cd "$(dirname "$0")/../spring-app" || exit 1
+
+# Ensure buildx is available
+if ! docker buildx version &> /dev/null; then
+    echo "Error: docker buildx is not available" >&2
+    exit 1
+fi
+
+# Create or use existing buildx builder
+BUILDER_NAME="multiarch-builder"
+if ! docker buildx inspect "${BUILDER_NAME}" &> /dev/null; then
+    echo "Creating buildx builder: ${BUILDER_NAME}"
+    docker buildx create --name "${BUILDER_NAME}" --use
+    echo ""
+else
+    echo "Using existing buildx builder: ${BUILDER_NAME}"
+    docker buildx use "${BUILDER_NAME}"
+    echo ""
+fi
+
+# Build arguments
+BUILD_ARGS=""
+if [ "${PUSH}" = "true" ]; then
+    BUILD_ARGS="--push"
+else
+    BUILD_ARGS="--load"
+    # Note: --load only supports single platform, so we'll build for current platform only
+    CURRENT_ARCH=$(uname -m)
+    if [ "${CURRENT_ARCH}" = "x86_64" ]; then
+        PLATFORMS="linux/amd64"
+    elif [ "${CURRENT_ARCH}" = "aarch64" ] || [ "${CURRENT_ARCH}" = "arm64" ]; then
+        PLATFORMS="linux/arm64"
+    fi
+    echo "Note: Loading to local Docker (--load) only supports current platform: ${PLATFORMS}"
+    echo "To build for multiple platforms, set PUSH=true to push to a registry"
+    echo ""
+fi
+
+echo "Building Docker image..."
+echo ""
+
+docker buildx build \
+    --builder "${BUILDER_NAME}" \
+    --platform "${PLATFORMS}" \
+    --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+    ${BUILD_ARGS} \
+    .
+
+echo ""
+echo "✓ Docker image built successfully"
+echo ""
+
+# Display image info (only if loaded locally)
+if [ "${PUSH}" != "true" ]; then
+    echo "Image details:"
+    docker images "${IMAGE_NAME}" | grep -E "REPOSITORY|${IMAGE_NAME}"
+    echo ""
+fi
+
+echo "Build complete!"
+echo ""
+echo "To run the image:"
+echo "  docker run -p 8080:8080 -e DATABASE_URL=jdbc:postgresql://host:5432/db ${IMAGE_NAME}:${IMAGE_TAG}"
+echo ""
+echo "To build for multiple architectures and push to registry:"
+echo "  PUSH=true IMAGE_NAME=registry/image PLATFORMS=linux/amd64,linux/arm64 ./build.sh"
+echo ""
+echo "To inspect the image:"
+echo "  docker inspect ${IMAGE_NAME}:${IMAGE_TAG}"
+echo ""

--- a/tests/examples/spring-boot-failover-test/scripts/configure-storage.sh
+++ b/tests/examples/spring-boot-failover-test/scripts/configure-storage.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Storage Configuration Script for pgskipper-operator
+# This script configures the Kubernetes cluster storage for pgskipper
+#
+# Usage:
+#   ./configure-storage.sh           # Interactive mode
+#   ./configure-storage.sh --auto    # Automatic mode (no prompts)
+
+set -e
+
+# Parse arguments
+AUTO_MODE=false
+if [[ "$1" == "--auto" ]]; then
+    AUTO_MODE=true
+fi
+
+if [ "$AUTO_MODE" = false ]; then
+    echo "===================================="
+    echo "pgskipper Storage Configuration"
+    echo "===================================="
+    echo ""
+fi
+
+# Check Kubernetes connectivity
+command -v kubectl >/dev/null 2>&1 || { echo "Error: kubectl is not installed" >&2; exit 1; }
+kubectl cluster-info >/dev/null 2>&1 || { echo "Error: Cannot connect to Kubernetes cluster" >&2; exit 1; }
+
+if [ "$AUTO_MODE" = false ]; then
+    echo "Current Storage Classes:"
+    kubectl get storageclass
+    echo ""
+fi
+
+# Check if there's a default storage class
+DEFAULT_SC=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+
+if [ -n "$DEFAULT_SC" ]; then
+    if [ "$AUTO_MODE" = false ]; then
+        echo "✓ Default storage class found: ${DEFAULT_SC}"
+        echo ""
+        echo "No action needed. pgskipper will use the default storage class."
+    fi
+    exit 0
+fi
+
+if [ "$AUTO_MODE" = false ]; then
+    echo "⚠ No default storage class configured"
+    echo ""
+fi
+
+# Get available storage classes
+STORAGE_CLASSES=$(kubectl get storageclass -o jsonpath='{.items[*].metadata.name}')
+
+if [ -z "$STORAGE_CLASSES" ]; then
+    echo "Error: No storage classes available in the cluster"
+    echo ""
+    echo "Solutions:"
+    echo ""
+    echo "For local development (Docker Desktop, OrbStack, Minikube, Kind):"
+    echo "  Install local-path provisioner:"
+    echo "  kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml"
+    echo ""
+    echo "For cloud providers:"
+    echo "  GKE: Storage classes are pre-configured"
+    echo "  EKS: Install EBS CSI driver"
+    echo "  AKS: Storage classes are pre-configured"
+    echo ""
+    exit 1
+fi
+
+if [ "$AUTO_MODE" = false ]; then
+    echo "Available storage classes:"
+    for sc in $STORAGE_CLASSES; do
+        echo "  - $sc"
+    done
+    echo ""
+fi
+
+# Try to auto-detect the best storage class
+SELECTED_SC=""
+
+# Preference order for local development
+for sc in local-path hostpath standard default; do
+    if echo "$STORAGE_CLASSES" | grep -qw "$sc"; then
+        SELECTED_SC="$sc"
+        break
+    fi
+done
+
+# If still not found, use the first available
+if [ -z "$SELECTED_SC" ]; then
+    SELECTED_SC=$(echo "$STORAGE_CLASSES" | awk '{print $1}')
+fi
+
+if [ "$AUTO_MODE" = false ]; then
+    echo "Recommended storage class: ${SELECTED_SC}"
+    echo ""
+
+    # Ask for confirmation
+    read -p "Set '$SELECTED_SC' as the default storage class? (y/n) " -n 1 -r
+    echo ""
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Storage configuration cancelled"
+        echo ""
+        echo "To manually set a default storage class:"
+        echo "  kubectl patch storageclass <name> -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}'"
+        exit 0
+    fi
+fi
+
+# Set the storage class as default
+if [ "$AUTO_MODE" = false ]; then
+    echo "Setting '${SELECTED_SC}' as default storage class..."
+else
+    echo "Auto-configuring storage class: ${SELECTED_SC}"
+fi
+kubectl patch storageclass "$SELECTED_SC" -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+echo "✓ Storage class configured"
+echo ""
+
+# Verify
+echo "Updated Storage Classes:"
+kubectl get storageclass
+echo ""
+
+# Test with a temporary PVC
+echo "Testing storage configuration..."
+
+cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-test-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+EOF
+
+# Wait a few seconds
+sleep 3
+
+# Check status
+PVC_STATUS=$(kubectl get pvc storage-test-pvc -o jsonpath='{.status.phase}')
+
+if [ "$PVC_STATUS" = "Bound" ]; then
+    echo "✓ Storage test successful - PVC bound to volume"
+elif [ "$PVC_STATUS" = "Pending" ]; then
+    echo "⚠ Storage test: PVC is pending (volume binding may be waiting for first consumer)"
+    echo "  This is normal for 'WaitForFirstConsumer' binding mode"
+else
+    echo "✗ Storage test failed - PVC status: ${PVC_STATUS}"
+fi
+
+# Clean up test PVC
+kubectl delete pvc storage-test-pvc >/dev/null 2>&1 || true
+
+echo ""
+echo "===================================="
+echo "Storage Configuration Complete"
+echo "===================================="
+echo ""
+echo "Next steps:"
+echo "1. Deploy pgskipper: ./scripts/setup.sh"
+echo "2. Verify PostgreSQL cluster: kubectl get pods -n postgres"
+echo ""
+echo "Note: If PVCs remain pending after setup, check:"
+echo "  kubectl describe pvc <pvc-name> -n postgres"
+echo ""

--- a/tests/examples/spring-boot-failover-test/scripts/test-reconnection.sh
+++ b/tests/examples/spring-boot-failover-test/scripts/test-reconnection.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# PostgreSQL Failover Test - Test Reconnection Script
+# This script monitors the application during failover and tests reconnection
+
+set -e
+
+NAMESPACE="default"
+APP_NAMESPACE="default"
+PG_NAMESPACE="postgres"
+
+echo "===================================="
+echo "PostgreSQL Reconnection Test"
+echo "===================================="
+echo ""
+
+# Check if kubectl is available
+command -v kubectl >/dev/null 2>&1 || { echo "Error: kubectl is not installed" >&2; exit 1; }
+
+# Get application pod
+APP_POD=$(kubectl get pods -n "$APP_NAMESPACE" -l app.kubernetes.io/name=postgresql-failover-test -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+if [ -z "$APP_POD" ]; then
+    echo "Error: Could not find application pod"
+    exit 1
+fi
+
+echo "Monitoring application pod: $APP_POD"
+echo ""
+
+# Function to call API endpoint
+call_api() {
+    local endpoint=$1
+    kubectl exec -n "$APP_NAMESPACE" "$APP_POD" -- wget -q -O - "http://localhost:8080/api/$endpoint" 2>/dev/null || echo "ERROR"
+}
+
+# Function to test database connectivity
+test_connectivity() {
+    echo "Testing database connectivity..."
+
+    # Get database info
+    DB_INFO=$(call_api "db-info")
+
+    if echo "$DB_INFO" | grep -q "PRIMARY\|REPLICA"; then
+        echo "✓ Database is connected"
+        echo "$DB_INFO" | grep -o '"role":"[^"]*"' | sed 's/"role":"//;s/"//'
+        echo "$DB_INFO" | grep -o '"serverAddress":"[^"]*"' | sed 's/"serverAddress":"//;s/"//'
+    else
+        echo "✗ Database is not connected"
+        return 1
+    fi
+}
+
+# Function to perform write test
+test_write() {
+    echo "Testing write operation..."
+
+    WRITE_RESULT=$(call_api "write-test?message=Failover+test+$(date +%s)")
+
+    if echo "$WRITE_RESULT" | grep -q '"success":true'; then
+        echo "✓ Write operation successful"
+    else
+        echo "✗ Write operation failed"
+        return 1
+    fi
+}
+
+# Function to get monitoring stats
+get_stats() {
+    echo "Monitoring Statistics:"
+
+    STATS=$(call_api "monitor-stats")
+
+    if [ "$STATS" != "ERROR" ]; then
+        echo "$STATS" | python3 -m json.tool 2>/dev/null || echo "$STATS"
+    else
+        echo "Failed to get stats"
+    fi
+}
+
+# Initial connectivity test
+echo "=== Initial State ==="
+test_connectivity
+echo ""
+get_stats
+echo ""
+
+# Start monitoring in background
+echo "Starting continuous monitoring..."
+echo "Press Ctrl+C to stop"
+echo ""
+echo "Timestamp          | Status       | Role    | Server IP        | Failures"
+echo "-------------------|--------------|---------|------------------|----------"
+
+CONSECUTIVE_FAILURES=0
+TOTAL_CHECKS=0
+
+# Continuous monitoring loop
+while true; do
+    TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
+    TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
+
+    # Get database info
+    DB_INFO=$(call_api "db-info")
+
+    if echo "$DB_INFO" | grep -q '"status":"CONNECTED"'; then
+        STATUS="CONNECTED"
+        ROLE=$(echo "$DB_INFO" | grep -o '"role":"[^"]*"' | sed 's/"role":"//;s/"//')
+        SERVER=$(echo "$DB_INFO" | grep -o '"serverAddress":"[^"]*"' | sed 's/"serverAddress":"//;s/"//')
+        CONSECUTIVE_FAILURES=0
+    else
+        STATUS="DISCONNECTED"
+        ROLE="UNKNOWN"
+        SERVER="N/A"
+        CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+    fi
+
+    # Get monitoring stats
+    STATS=$(call_api "monitor-stats")
+    TOTAL_FAILURES=$(echo "$STATS" | grep -o '"totalFailures":[0-9]*' | grep -o '[0-9]*' || echo "0")
+
+    # Print status line
+    printf "%s | %-12s | %-7s | %-16s | %s\n" \
+        "$TIMESTAMP" "$STATUS" "$ROLE" "$SERVER" "$TOTAL_FAILURES"
+
+    # Alert on failures
+    if [ "$CONSECUTIVE_FAILURES" -eq 1 ]; then
+        echo "⚠ CONNECTION LOST! Failover may be in progress..."
+    elif [ "$CONSECUTIVE_FAILURES" -eq 10 ]; then
+        echo "⚠ Connection has been down for 50 seconds"
+    fi
+
+    # Wait 5 seconds before next check
+    sleep 5
+done

--- a/tests/examples/spring-boot-failover-test/scripts/trigger-failover.sh
+++ b/tests/examples/spring-boot-failover-test/scripts/trigger-failover.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# PostgreSQL Failover Test - Trigger Failover Script
+# This script triggers a failover by deleting the primary PostgreSQL pod
+
+set -e
+
+NAMESPACE="postgres"
+
+echo "===================================="
+echo "PostgreSQL Failover Trigger"
+echo "===================================="
+echo ""
+
+# Check if kubectl is available
+command -v kubectl >/dev/null 2>&1 || { echo "Error: kubectl is not installed" >&2; exit 1; }
+
+# Get current primary pod
+echo "Identifying current primary PostgreSQL pod..."
+PRIMARY_POD=$(kubectl get pods -n "$NAMESPACE" --selector=pgtype=master -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+if [ -z "$PRIMARY_POD" ]; then
+    echo "Error: Could not find primary PostgreSQL pod"
+    echo "Make sure the PostgreSQL cluster is running"
+    exit 1
+fi
+
+echo "Current primary pod: $PRIMARY_POD"
+echo ""
+
+# Get current primary IP
+PRIMARY_IP=$(kubectl get pod "$PRIMARY_POD" -n "$NAMESPACE" -o jsonpath='{.status.podIP}')
+echo "Primary IP: $PRIMARY_IP"
+echo ""
+
+# Ask for confirmation
+echo "This will delete the primary pod to trigger failover."
+echo "Patroni will automatically promote a replica to primary."
+read -p "Do you want to continue? (y/n) " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Failover cancelled"
+    exit 0
+fi
+echo ""
+
+# Get current timestamp
+START_TIME=$(date +%s)
+echo "Failover started at: $(date)"
+echo ""
+
+# Delete primary pod
+echo "Deleting primary pod: $PRIMARY_POD"
+kubectl delete pod "$PRIMARY_POD" -n "$NAMESPACE" --grace-period=0 --force
+
+echo "✓ Primary pod deleted"
+echo ""
+
+# Monitor failover process
+echo "Monitoring failover process..."
+echo ""
+
+# Wait for new primary to be elected
+MAX_WAIT=120  # 2 minutes
+ELAPSED=0
+NEW_PRIMARY=""
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+
+    # Try to get new primary pod (different from the deleted one)
+    NEW_PRIMARY=$(kubectl get pods -n "$NAMESPACE" --selector=pgtype=master -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -n "$NEW_PRIMARY" ] && [ "$NEW_PRIMARY" != "$PRIMARY_POD" ]; then
+        break
+    fi
+
+    echo "Waiting for new primary to be elected... (${ELAPSED}s)"
+done
+
+if [ -z "$NEW_PRIMARY" ] || [ "$NEW_PRIMARY" == "$PRIMARY_POD" ]; then
+    echo "Error: New primary was not elected within ${MAX_WAIT} seconds"
+    exit 1
+fi
+
+END_TIME=$(date +%s)
+FAILOVER_DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "===================================="
+echo "Failover Complete!"
+echo "===================================="
+echo ""
+echo "Old primary pod: $PRIMARY_POD (IP: $PRIMARY_IP)"
+echo "New primary pod: $NEW_PRIMARY"
+
+# Get new primary IP
+NEW_PRIMARY_IP=$(kubectl get pod "$NEW_PRIMARY" -n "$NAMESPACE" -o jsonpath='{.status.podIP}')
+echo "New primary IP: $NEW_PRIMARY_IP"
+echo ""
+echo "Failover duration: ${FAILOVER_DURATION} seconds"
+echo ""
+
+# Display current cluster status
+echo "Current PostgreSQL Cluster Status:"
+kubectl get pods -n "$NAMESPACE" -l app=postgres
+echo ""
+
+echo "Pod details:"
+kubectl get pods -n "$NAMESPACE" -l app=postgres -o wide
+echo ""
+
+echo "Next steps:"
+echo "1. Monitor application logs to verify reconnection:"
+echo "   kubectl logs -f -n default -l app.kubernetes.io/name=postgresql-failover-test"
+echo ""
+echo "2. Check monitoring stats:"
+echo "   kubectl port-forward -n default svc/postgresql-failover-test 8080:8080"
+echo "   curl http://localhost:8080/api/monitor-stats"
+echo ""
+echo "3. Verify database connection:"
+echo "   curl http://localhost:8080/api/db-info"
+echo ""

--- a/tests/examples/spring-boot-failover-test/spring-app/BUILD.md
+++ b/tests/examples/spring-boot-failover-test/spring-app/BUILD.md
@@ -1,0 +1,269 @@
+# Build Instructions
+
+## Quick Start
+
+This project uses **Cloud Native Buildpacks** to build container images.
+
+```bash
+# From project root
+./scripts/build.sh
+
+# Or from spring-app directory
+mvn spring-boot:build-image
+```
+
+## Build Features
+
+- ✅ **No Dockerfile needed** - Buildpacks auto-configure everything
+- ✅ **Automatic security updates** - Rebuild to get latest patches
+- ✅ **Optimized layer caching** - Faster builds automatically
+- ✅ **SBOM included** - Software Bill of Materials for compliance
+- ✅ **Production-ready defaults** - Best practices applied automatically
+
+## Build Commands
+
+| Task | Command |
+|------|---------|
+| **Build image** | `mvn spring-boot:build-image` |
+| **Custom tag** | `-Dspring-boot.build-image.imageName=app:v1` |
+| **Set Java version** | `-Dspring-boot.build-image.env.BP_JVM_VERSION=21` |
+| **Use tiny builder** | `-Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny` |
+| **Build speed (first)** | ~3-5 min |
+| **Build speed (cached)** | ~30-60 sec |
+| **Image size** | ~300-400 MB (base), ~280 MB (tiny) |
+
+## Configuration Files
+
+### Buildpacks Configuration
+
+**`pom.xml` (Maven Plugin)**
+```xml
+<plugin>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-maven-plugin</artifactId>
+    <configuration>
+        <image>
+            <name>postgresql-failover-test:${project.version}</name>
+            <env>
+                <BP_JVM_VERSION>17</BP_JVM_VERSION>
+                <BPE_APPEND_JAVA_TOOL_OPTIONS>-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0</BPE_APPEND_JAVA_TOOL_OPTIONS>
+            </env>
+            <buildpacks>
+                <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
+            </buildpacks>
+        </image>
+    </configuration>
+</plugin>
+```
+
+**`project.toml` (Optional - for Pack CLI)**
+```toml
+[build]
+  include = ["src/", "pom.xml"]
+
+[[build.env]]
+name = "BP_JVM_VERSION"
+value = "17"
+
+[[build.env]]
+name = "BPE_APPEND_JAVA_TOOL_OPTIONS"
+value = "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+```
+
+## Environment Variables
+
+### Buildpacks Environment Variables
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `BP_JVM_VERSION` | Java version | `17` | `21` |
+| `BP_JVM_TYPE` | JRE or JDK | `JRE` | `JDK` |
+| `BP_MAVEN_BUILD_ARGUMENTS` | Maven args | `package` | `clean package -DskipTests` |
+| `BPE_APPEND_JAVA_TOOL_OPTIONS` | JVM options | - | `-XX:MaxRAMPercentage=75.0` |
+| `BP_JVM_JLINK_ENABLED` | Custom JRE with jlink | `false` | `true` |
+
+Set at build time:
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.env.BP_JVM_VERSION=21
+```
+
+Or in `pom.xml`:
+```xml
+<env>
+    <BP_JVM_VERSION>21</BP_JVM_VERSION>
+</env>
+```
+
+## Local Development
+
+### Run with Docker Compose
+
+```bash
+cd spring-app
+docker-compose up --build
+```
+
+This starts:
+- PostgreSQL database
+- Spring Boot application (built with buildpacks)
+
+### Run without Docker
+
+```bash
+cd spring-app
+
+# Build JAR
+mvn clean package
+
+# Run with local PostgreSQL
+java -jar target/*.jar \
+    --spring.datasource.url=jdbc:postgresql://localhost:5432/testdb \
+    --spring.datasource.username=postgres \
+    --spring.datasource.password=postgres
+```
+
+## CI/CD Examples
+
+### GitHub Actions
+
+```yaml
+name: Build Image
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Buildpacks
+        run: |
+          cd spring-app
+          mvn spring-boot:build-image \
+            -Dspring-boot.build-image.imageName=${{ github.repository }}:${{ github.sha }}
+
+      - name: Push to registry
+        run: docker push ${{ github.repository }}:${{ github.sha }}
+```
+
+### GitLab CI
+
+```yaml
+build:
+  image: maven:3.9-eclipse-temurin-17
+  services:
+    - docker:dind
+  script:
+    - cd spring-app
+    - mvn spring-boot:build-image -DskipTests
+  only:
+    - main
+```
+
+### Jenkins
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                dir('spring-app') {
+                    sh 'mvn spring-boot:build-image'
+                }
+            }
+        }
+    }
+}
+```
+
+## Image Analysis
+
+```bash
+# Show buildpack metadata
+pack inspect-image postgresql-failover-test:latest
+
+# Extract SBOM (Software Bill of Materials)
+docker run --rm postgresql-failover-test:latest \
+    cat /layers/sbom/launch/paketo-buildpacks_*/sbom.syft.json > sbom.json
+
+# Analyze for vulnerabilities
+grype postgresql-failover-test:latest
+
+# Show image layers
+docker history postgresql-failover-test:latest
+```
+
+## Troubleshooting
+
+### Build fails with "Cannot connect to Docker daemon"
+
+```bash
+# Check Docker is running
+docker ps
+
+# On macOS/Windows, ensure Docker Desktop is running
+```
+
+### Maven build fails
+
+```bash
+# Clean and retry
+mvn clean
+mvn spring-boot:build-image
+```
+
+### Out of disk space
+
+```bash
+# Clean Docker cache
+docker system prune -a
+
+# Clean Maven cache
+rm -rf ~/.m2/repository
+```
+
+### Want smaller images
+
+**Option 1: Use tiny builder**
+```bash
+mvn spring-boot:build-image \
+    -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+```
+
+**Option 2: Enable jlink (custom JRE)**
+```xml
+<env>
+    <BP_JVM_JLINK_ENABLED>true</BP_JVM_JLINK_ENABLED>
+</env>
+```
+
+## Performance Tips
+
+1. **Use buildpacks for consistency** - Same image every time
+2. **Enable layer caching** - Automatic with buildpacks
+3. **Skip tests during image build** - Run tests separately
+4. **Use `.dockerignore`** - Exclude unnecessary files
+5. **Multi-stage builds** - Already optimized in buildpacks
+
+## Security Best Practices
+
+1. **SBOM Generation** - Buildpacks create it automatically
+2. **Vulnerability Scanning** - Use `grype` or `trivy`
+3. **Non-root user** - Both approaches use non-root
+4. **Minimal base images** - Use `tiny` builder for buildpacks
+5. **Regular updates** - Rebuild images weekly
+
+## Further Reading
+
+- [Spring Boot Buildpacks Documentation](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#build-image)
+- [Paketo Buildpacks](https://paketo.io/)
+- [Docker BuildKit](https://docs.docker.com/build/buildkit/)
+- [Cloud Native Buildpacks](https://buildpacks.io/)

--- a/tests/examples/spring-boot-failover-test/spring-app/Dockerfile
+++ b/tests/examples/spring-boot-failover-test/spring-app/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage Dockerfile for Spring Boot Application
+# Supports both amd64 and arm64 architectures
+# Uses BuildKit cache mounts for faster builds
+
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+# Copy pom.xml and download dependencies (cached layer)
+COPY pom.xml .
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:go-offline -B
+
+# Copy source code and build
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package -DskipTests -B && \
+    # Copy the built JAR to a location outside the cache mount
+    mkdir -p /app/output && \
+    cp /app/target/*.jar /app/output/app.jar
+
+# Stage 2: Runtime image
+FROM eclipse-temurin:17-jre-jammy
+
+# Set up non-root user for security
+RUN groupadd -r spring && useradd -r -g spring spring
+
+WORKDIR /app
+
+# Copy the built JAR from builder stage
+COPY --from=builder /app/output/app.jar app.jar
+
+# Change ownership to non-root user
+RUN chown -R spring:spring /app
+
+USER spring
+
+# JVM options for container environments
+ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
+
+# Expose application port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tests/examples/spring-boot-failover-test/spring-app/docker-compose.yml
+++ b/tests/examples/spring-boot-failover-test/spring-app/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.8'
+
+# Docker Compose file for local development and testing
+# This demonstrates BuildKit usage with docker-compose
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # Enable BuildKit features
+      cache_from:
+        - postgresql-failover-test:latest
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+    image: postgresql-failover-test:latest
+    container_name: failover-test-app
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - DATABASE_URL=jdbc:postgresql://postgres:5432/postgres?targetServerType=primary
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=postgres
+      - JAVA_OPTS=-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - app-network
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: failover-test-postgres
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - app-network
+
+volumes:
+  postgres-data:
+
+networks:
+  app-network:
+    driver: bridge

--- a/tests/examples/spring-boot-failover-test/spring-app/pom.xml
+++ b/tests/examples/spring-boot-failover-test/spring-app/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>postgresql-failover-test</artifactId>
+    <version>1.0.0</version>
+    <name>PostgreSQL Failover Test Application</name>
+    <description>Spring Boot application for testing PostgreSQL failover and reconnection</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starter Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Starter Data JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Actuator for health checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- HikariCP (already included in Spring Boot, but explicit for clarity) -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+
+        <!-- Lombok for reducing boilerplate -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/examples/spring-boot-failover-test/spring-app/project.toml
+++ b/tests/examples/spring-boot-failover-test/spring-app/project.toml
@@ -1,0 +1,61 @@
+# Cloud Native Buildpacks Project Descriptor
+# This file configures buildpack behavior for the application
+
+[_]
+schema-version = "0.2"
+
+# Build configuration
+[build]
+  # Include/exclude files from the build
+  include = [
+    "src/",
+    "pom.xml"
+  ]
+
+  exclude = [
+    "target/",
+    ".git/",
+    ".idea/",
+    "*.iml",
+    ".DS_Store"
+  ]
+
+# Build environment variables
+[[build.env]]
+name = "BP_JVM_VERSION"
+value = "17"
+
+[[build.env]]
+name = "BP_MAVEN_BUILD_ARGUMENTS"
+value = "clean package -DskipTests"
+
+[[build.env]]
+name = "BPE_DELIM_JAVA_TOOL_OPTIONS"
+value = " "
+
+[[build.env]]
+name = "BPE_APPEND_JAVA_TOOL_OPTIONS"
+value = "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+
+# Buildpack configuration for specific optimizations
+[[build.env]]
+name = "BP_JVM_JLINK_ENABLED"
+value = "false"  # Set to true to create a custom JRE with jlink
+
+[[build.env]]
+name = "BP_JVM_TYPE"
+value = "JRE"  # Use JRE instead of JDK for smaller image
+
+# Health check configuration
+[[build.env]]
+name = "THC_PATH"
+value = "/api/health"
+
+# Metadata
+[metadata]
+  [metadata.application]
+    name = "PostgreSQL Failover Test"
+    version = "1.0.0"
+
+  [metadata.build]
+    description = "Spring Boot application for testing PostgreSQL failover and reconnection"

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/Application.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/Application.java
@@ -1,0 +1,14 @@
+package com.example.pgtest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/controller/HealthController.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/controller/HealthController.java
@@ -1,0 +1,138 @@
+package com.example.pgtest.controller;
+
+import com.example.pgtest.model.TestEntity;
+import com.example.pgtest.service.ConnectionMonitor;
+import com.example.pgtest.service.DatabaseService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class HealthController {
+
+    @Autowired
+    private DatabaseService databaseService;
+
+    @Autowired
+    private ConnectionMonitor connectionMonitor;
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "UP");
+        response.put("timestamp", LocalDateTime.now());
+        response.put("application", "PostgreSQL Failover Test");
+
+        try {
+            boolean connectionValid = databaseService.testConnection();
+            response.put("database", connectionValid ? "UP" : "DOWN");
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            response.put("database", "DOWN");
+            response.put("error", e.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
+        }
+    }
+
+    @GetMapping("/db-info")
+    public ResponseEntity<Map<String, Object>> getDatabaseInfo() {
+        try {
+            Map<String, Object> dbInfo = databaseService.getDatabaseInfo();
+            return ResponseEntity.ok(dbInfo);
+        } catch (Exception e) {
+            log.error("Error getting database info", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/pool-info")
+    public ResponseEntity<Map<String, Object>> getPoolInfo() {
+        try {
+            Map<String, Object> poolInfo = databaseService.getConnectionPoolInfo();
+            return ResponseEntity.ok(poolInfo);
+        } catch (Exception e) {
+            log.error("Error getting pool info", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/monitor-stats")
+    public ResponseEntity<Map<String, Object>> getMonitorStats() {
+        try {
+            Map<String, Object> stats = connectionMonitor.getMonitoringStats();
+            return ResponseEntity.ok(stats);
+        } catch (Exception e) {
+            log.error("Error getting monitor stats", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/write-test")
+    public ResponseEntity<Map<String, Object>> writeTest(@RequestParam(defaultValue = "Test message") String message) {
+        try {
+            TestEntity entity = databaseService.writeTestRecord(message);
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("id", entity.getId());
+            response.put("message", entity.getMessage());
+            response.put("hostname", entity.getHostname());
+            response.put("createdAt", entity.getCreatedAt());
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Error writing test record", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/read-test")
+    public ResponseEntity<Map<String, Object>> readTest() {
+        try {
+            List<TestEntity> records = databaseService.getAllTestRecords();
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("count", records.size());
+            response.put("records", records);
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Error reading test records", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/test-connection")
+    public ResponseEntity<Map<String, Object>> testConnection() {
+        try {
+            boolean valid = databaseService.testConnection();
+            Map<String, Object> response = new HashMap<>();
+            response.put("connectionValid", valid);
+            response.put("timestamp", LocalDateTime.now());
+
+            if (valid) {
+                Map<String, Object> dbInfo = databaseService.getDatabaseInfo();
+                response.putAll(dbInfo);
+            }
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Connection test failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("connectionValid", false, "error", e.getMessage()));
+        }
+    }
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/model/TestEntity.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/model/TestEntity.java
@@ -1,0 +1,37 @@
+package com.example.pgtest.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "connection_tests")
+@Data
+@NoArgsConstructor
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "hostname")
+    private String hostname;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public TestEntity(String message, String hostname) {
+        this.message = message;
+        this.hostname = hostname;
+    }
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/repository/TestRepository.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/repository/TestRepository.java
@@ -1,0 +1,19 @@
+package com.example.pgtest.repository;
+
+import com.example.pgtest.model.TestEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestRepository extends JpaRepository<TestEntity, Long> {
+
+    @Query(value = "SELECT version()", nativeQuery = true)
+    String getPostgresVersion();
+
+    @Query(value = "SELECT cast(inet_server_addr() as text)", nativeQuery = true)
+    String getServerAddress();
+
+    @Query(value = "SELECT pg_is_in_recovery()", nativeQuery = true)
+    Boolean isInRecovery();
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/service/ConnectionMonitor.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/service/ConnectionMonitor.java
@@ -1,0 +1,125 @@
+package com.example.pgtest.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+@Slf4j
+public class ConnectionMonitor {
+
+    @Autowired
+    private DatabaseService databaseService;
+
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final AtomicInteger consecutiveSuccesses = new AtomicInteger(0);
+    private final AtomicLong totalChecks = new AtomicLong(0);
+    private final AtomicLong totalFailures = new AtomicLong(0);
+    private String lastKnownPrimary = "UNKNOWN";
+    private String lastKnownRole = "UNKNOWN";
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Monitor database connection every 5 seconds
+     */
+    @Scheduled(fixedRate = 5000, initialDelay = 10000)
+    public void monitorConnection() {
+        totalChecks.incrementAndGet();
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+
+        try {
+            Map<String, Object> dbInfo = databaseService.getDatabaseInfo();
+
+            if ("CONNECTED".equals(dbInfo.get("status"))) {
+                consecutiveSuccesses.incrementAndGet();
+                int failures = consecutiveFailures.getAndSet(0);
+
+                String currentRole = (String) dbInfo.get("role");
+                String currentServer = (String) dbInfo.get("serverAddress");
+
+                // Detect role change (failover)
+                if (!lastKnownRole.equals("UNKNOWN") && !lastKnownRole.equals(currentRole)) {
+                    log.warn("========================================");
+                    log.warn("ROLE CHANGE DETECTED!");
+                    log.warn("Previous role: {}", lastKnownRole);
+                    log.warn("Current role: {}", currentRole);
+                    log.warn("Previous server: {}", lastKnownPrimary);
+                    log.warn("Current server: {}", currentServer);
+                    log.warn("Consecutive failures before recovery: {}", failures);
+                    log.warn("========================================");
+                }
+
+                // Detect server change (failover)
+                if (!lastKnownPrimary.equals("UNKNOWN") &&
+                    !lastKnownPrimary.equals(currentServer) &&
+                    "PRIMARY".equals(currentRole)) {
+                    log.warn("========================================");
+                    log.warn("PRIMARY SERVER CHANGE DETECTED!");
+                    log.warn("Previous primary: {}", lastKnownPrimary);
+                    log.warn("New primary: {}", currentServer);
+                    log.warn("Consecutive failures before recovery: {}", failures);
+                    log.warn("========================================");
+                }
+
+                lastKnownRole = currentRole;
+                if ("PRIMARY".equals(currentRole)) {
+                    lastKnownPrimary = currentServer;
+                }
+
+                if (failures > 0) {
+                    log.info("[{}] ✓ CONNECTION RESTORED - Server: {}, Role: {}, Downtime checks: {}",
+                            timestamp, currentServer, currentRole, failures);
+                } else if (consecutiveSuccesses.get() % 12 == 1) {  // Log every minute (12 * 5s)
+                    log.info("[{}] ✓ Healthy - Server: {}, Role: {}, Total checks: {}, Total failures: {}",
+                            timestamp, currentServer, currentRole, totalChecks.get(), totalFailures.get());
+                }
+
+            } else {
+                handleConnectionFailure(timestamp, dbInfo);
+            }
+
+        } catch (Exception e) {
+            handleConnectionFailure(timestamp, Map.of("error", e.getMessage()));
+        }
+    }
+
+    private void handleConnectionFailure(String timestamp, Map<String, Object> dbInfo) {
+        consecutiveFailures.incrementAndGet();
+        totalFailures.incrementAndGet();
+        consecutiveSuccesses.set(0);
+
+        String error = dbInfo.get("error") != null ? dbInfo.get("error").toString() : "Unknown error";
+
+        log.error("[{}] ✗ CONNECTION FAILED - Consecutive failures: {}, Total failures: {}, Error: {}",
+                timestamp, consecutiveFailures.get(), totalFailures.get(), error);
+
+        if (consecutiveFailures.get() == 1) {
+            log.warn("========================================");
+            log.warn("DATABASE CONNECTION LOST!");
+            log.warn("Last known primary: {}", lastKnownPrimary);
+            log.warn("Last known role: {}", lastKnownRole);
+            log.warn("========================================");
+        }
+    }
+
+    public Map<String, Object> getMonitoringStats() {
+        return Map.of(
+                "totalChecks", totalChecks.get(),
+                "totalFailures", totalFailures.get(),
+                "consecutiveFailures", consecutiveFailures.get(),
+                "consecutiveSuccesses", consecutiveSuccesses.get(),
+                "lastKnownPrimary", lastKnownPrimary,
+                "lastKnownRole", lastKnownRole,
+                "uptime", String.format("%.2f%%",
+                        100.0 * (totalChecks.get() - totalFailures.get()) / Math.max(totalChecks.get(), 1))
+        );
+    }
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/service/DatabaseService.java
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/java/com/example/pgtest/service/DatabaseService.java
@@ -1,0 +1,117 @@
+package com.example.pgtest.service;
+
+import com.example.pgtest.model.TestEntity;
+import com.example.pgtest.repository.TestRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.net.InetAddress;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class DatabaseService {
+
+    @Autowired
+    private TestRepository testRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> getDatabaseInfo() {
+        Map<String, Object> info = new HashMap<>();
+
+        try {
+            String version = testRepository.getPostgresVersion();
+            String serverAddress = testRepository.getServerAddress();
+            Boolean isReplica = testRepository.isInRecovery();
+
+            info.put("version", version);
+            info.put("serverAddress", serverAddress);
+            info.put("isReplica", isReplica);
+            info.put("role", isReplica ? "REPLICA" : "PRIMARY");
+            info.put("timestamp", LocalDateTime.now());
+            info.put("status", "CONNECTED");
+
+            log.info("Database info: server={}, role={}, version={}",
+                    serverAddress, info.get("role"), version);
+
+        } catch (Exception e) {
+            log.error("Failed to get database info", e);
+            info.put("status", "ERROR");
+            info.put("error", e.getMessage());
+        }
+
+        return info;
+    }
+
+    @Transactional
+    public TestEntity writeTestRecord(String message) {
+        try {
+            String hostname = InetAddress.getLocalHost().getHostName();
+            TestEntity entity = new TestEntity(message, hostname);
+            TestEntity saved = testRepository.save(entity);
+
+            log.info("Successfully wrote test record: id={}, message={}",
+                    saved.getId(), saved.getMessage());
+
+            return saved;
+        } catch (Exception e) {
+            log.error("Failed to write test record", e);
+            throw new RuntimeException("Failed to write test record", e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<TestEntity> getAllTestRecords() {
+        try {
+            return testRepository.findAll();
+        } catch (Exception e) {
+            log.error("Failed to read test records", e);
+            throw new RuntimeException("Failed to read test records", e);
+        }
+    }
+
+    public Map<String, Object> getConnectionPoolInfo() {
+        Map<String, Object> poolInfo = new HashMap<>();
+
+        try (Connection conn = dataSource.getConnection()) {
+            poolInfo.put("connectionValid", conn.isValid(5));
+            poolInfo.put("connectionCatalog", conn.getCatalog());
+            poolInfo.put("connectionReadOnly", conn.isReadOnly());
+            poolInfo.put("connectionClass", conn.getClass().getName());
+            poolInfo.put("timestamp", LocalDateTime.now());
+
+            // Try to get HikariCP specific info
+            if (dataSource.getClass().getName().contains("Hikari")) {
+                poolInfo.put("poolType", "HikariCP");
+            }
+
+        } catch (SQLException e) {
+            log.error("Failed to get connection pool info", e);
+            poolInfo.put("error", e.getMessage());
+        }
+
+        return poolInfo;
+    }
+
+    public boolean testConnection() {
+        try (Connection conn = dataSource.getConnection()) {
+            boolean valid = conn.isValid(5);
+            log.info("Connection test: valid={}", valid);
+            return valid;
+        } catch (SQLException e) {
+            log.error("Connection test failed", e);
+            return false;
+        }
+    }
+}

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/resources/application.yml
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/resources/application.yml
@@ -1,0 +1,98 @@
+spring:
+  application:
+    name: postgresql-failover-test
+
+  datasource:
+    # Multi-host PostgreSQL JDBC URL for automatic failover
+    # Format: jdbc:postgresql://host1:5432,host2:5432,host3:5432/dbname?targetServerType=primary
+    # This will be overridden by environment variables in Kubernetes
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/postgres?targetServerType=primary&loadBalanceHosts=true}
+    username: ${DATABASE_USERNAME:postgres}
+    password: ${DATABASE_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+    # HikariCP connection pool configuration for failover resilience
+    hikari:
+      # Connection pool sizing
+      minimum-idle: 2
+      maximum-pool-size: 10
+
+      # Connection timeout settings
+      connection-timeout: 10000  # 10 seconds - time to wait for connection from pool
+      validation-timeout: 5000   # 5 seconds - time to wait for connection validation
+
+      # Connection lifecycle
+      max-lifetime: 600000       # 10 minutes - maximum lifetime of a connection
+      idle-timeout: 300000       # 5 minutes - maximum idle time before connection is retired
+
+      # Connection validation
+      connection-test-query: SELECT 1
+
+      # Leak detection (helps identify connection leaks during testing)
+      leak-detection-threshold: 60000  # 60 seconds
+
+      # Pool name for logging
+      pool-name: PostgreSQL-FailoverPool
+
+      # Auto-commit
+      auto-commit: true
+
+      # Additional PostgreSQL-specific properties
+      data-source-properties:
+        # Socket timeout for detecting dead connections
+        socketTimeout: 30
+        # Login timeout
+        loginTimeout: 10
+        # TCP keepalive
+        tcpKeepAlive: true
+        # Application name for PostgreSQL logs
+        ApplicationName: spring-failover-test
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # Auto-create/update schema (for testing only)
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        # Connection handling
+        connection:
+          provider_disables_autocommit: false
+        # Query timeout (30 seconds)
+        query_timeout: 30000
+        # Enable statistics for monitoring
+        generate_statistics: false
+
+  # Actuator endpoints for health monitoring
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: health,info,metrics
+    endpoint:
+      health:
+        show-details: always
+
+# Logging configuration
+logging:
+  level:
+    root: INFO
+    com.example.pgtest: DEBUG
+    com.zaxxer.hikari: DEBUG
+    org.postgresql: INFO
+    org.hibernate.SQL: INFO
+    org.hibernate.type.descriptor.sql.BasicBinder: INFO
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+# Server configuration
+server:
+  port: 8080
+  shutdown: graceful
+
+# Application-specific settings
+app:
+  monitoring:
+    enabled: true
+    interval: 5000  # 5 seconds

--- a/tests/examples/spring-boot-failover-test/spring-app/src/main/resources/schema.sql
+++ b/tests/examples/spring-boot-failover-test/spring-app/src/main/resources/schema.sql
@@ -1,0 +1,12 @@
+-- Schema for connection testing
+-- This will be created automatically by Hibernate, but provided for reference
+
+CREATE TABLE IF NOT EXISTS connection_tests (
+    id BIGSERIAL PRIMARY KEY,
+    message VARCHAR(500) NOT NULL,
+    hostname VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for faster queries
+CREATE INDEX IF NOT EXISTS idx_connection_tests_created_at ON connection_tests(created_at);


### PR DESCRIPTION
The PR adds [helmfile](https://helmfile.readthedocs.io/) configuration which deploys pgskipper and a sample application to verify connectivity and failover behavior.

Here's what I get with macOS + OrbStack:

```
$ USE_LOCAL_IMAGES=true helmfile -e orbstack sync
...
hook[postsync] logs | Waiting for application pods to be ready...
hook[postsync] logs | pod/failover-test-postgresql-failover-test-7c8589c549-6pb45 condition met
hook[postsync] logs | pod/failover-test-postgresql-failover-test-7c8589c549-qhtjw condition met
hook[postsync] logs | Application is ready!
hook[postsync] logs |
hook[postsync] logs | =====================================
hook[postsync] logs | Deployment Complete!
hook[postsync] logs | =====================================
hook[postsync] logs |
hook[postsync] logs | PostgreSQL Cluster Status:
hook[postsync] logs |
hook[postsync] logs | Application Status:
hook[postsync] logs | NAME                                                      READY   STATUS    RESTARTS   AGE
hook[postsync] logs | failover-test-postgresql-failover-test-7c8589c549-6pb45   1/1     Running   0          34s
hook[postsync] logs | failover-test-postgresql-failover-test-7c8589c549-qhtjw   1/1     Running   0          34s
hook[postsync] logs |
hook[postsync] logs | Services:
hook[postsync] logs | NAME                   TYPE        CLUSTER-IP        EXTERNAL-IP   PORT(S)                      AGE
hook[postsync] logs | monitoring-collector   ClusterIP   192.168.194.171   <none>        8000/TCP,9273/TCP            76s
hook[postsync] logs | patroni-headless       ClusterIP   None              <none>        5432/TCP,8008/TCP            61s
hook[postsync] logs | pg-patroni             ClusterIP   192.168.194.203   <none>        5432/TCP,8008/TCP,22/TCP     61s
hook[postsync] logs | pg-patroni-api         ClusterIP   192.168.194.234   <none>        5432/TCP,8008/TCP,22/TCP     31h
hook[postsync] logs | pg-patroni-ro          ClusterIP   192.168.194.178   <none>        5432/TCP,8008/TCP,22/TCP     31h
hook[postsync] logs | postgres-operator      ClusterIP   192.168.194.145   <none>        8383/TCP,8080/TCP,8443/TCP   31h
hook[postsync] logs |
hook[postsync] logs | Next steps:
hook[postsync] logs | 1. Check application logs: kubectl logs -f -n default -l app.kubernetes.io/name=postgresql-failover-test
hook[postsync] logs | 2. Test failover: ./scripts/trigger-failover.sh
hook[postsync] logs | 3. Monitor reconnection: ./scripts/test-reconnection.sh
```