### PR TITLE
fix: set ownerReferences in CreateServiceIfNotExists and CreateConfigMapIfNotExists

### DIFF
--- a/operator/pkg/helper/resource_management.go
+++ b/operator/pkg/helper/resource_management.go
@@ -756,6 +756,7 @@ func (rm *ResourceManager) CreateServiceIfNotExists(service *corev1.Service) err
 	}, foundService)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info(fmt.Sprintf("Creating %s k8s service", service.Name))
+		service.OwnerReferences = rm.GetOwnerReferences()
 		service.Labels = rm.getLabels(service.ObjectMeta)
 		err = rm.kubeClient.Create(context.TODO(), service)
 		if err != nil {
@@ -775,6 +776,7 @@ func (rm *ResourceManager) CreateConfigMapIfNotExists(cm *corev1.ConfigMap) erro
 	}, foundCm)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info(fmt.Sprintf("Creating %s configMap", cm.Name))
+		cm.OwnerReferences = rm.GetOwnerReferences()
 		cm.Labels = rm.getLabels(cm.ObjectMeta)
 		err = rm.kubeClient.Create(context.TODO(), cm)
 		if err != nil {


### PR DESCRIPTION
These methods were missing ownerReferences, unlike their CreateOrUpdate counterparts. This caused operator-created services (e.g. pg-patroni-api, pg-patroni-ro) and config maps to be orphaned after helm uninstall, since Kubernetes garbage collector had no owner to cascade from.

Just wondering: do you think a test case is needed for the change?