### PR TITLE
fix: use psycopg2 instead of psycopg2-binary to link against system libpq

### DIFF
--- a/services/patroni/Dockerfile
+++ b/services/patroni/Dockerfile
@@ -133,7 +133,7 @@ RUN apt-get install -y alien vmtouch openssh-server
 
 RUN cat /root/.pip/pip.conf
 RUN python3 -m pip install -U setuptools==78.1.1 wheel==0.38.0
-RUN python3 -m pip install psutil patroni[kubernetes,etcd]==3.3.5 psycopg2-binary==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
+RUN python3 -m pip install psutil patroni[kubernetes,etcd]==3.3.5 psycopg2==2.9.5 requests python-dateutil urllib3 six prettytable --no-cache
 # Explicitly install patched libaom3 version
 RUN apt-get --no-install-recommends install -y libaom3=3.3.0-1ubuntu0.1 || apt-get --no-install-recommends install -y libaom3
 RUN mv /var/lib/postgresql /var/lib/pgsql


### PR DESCRIPTION
`psycopg2-binary` bundles its own `libpq 9.6`, which does not support the `target_session_attrs` connection parameter (requires `libpq >= 10`).

This causes Patroni replicas to log errors every second:
  `psycopg2.ProgrammingError: invalid dsn: invalid connection option "target_session_attrs"`

The error originates in Patroni's `rewind.py` `check_leader_is_not_in_recovery()`, which sets `target_session_attrs='read-write'` for `PG >= 10`.

Switching to `psycopg2` (non-binary) compiles from source against the system's `libpq-dev`, which fully supports the parameter. `libpq-dev` is already present via the `postgresql-server-dev` dependency.