### PR TITLE
fix: update test pipeline version

### DIFF
--- a/.github/workflows/run_nightly_tests.yaml
+++ b/.github/workflows/run_nightly_tests.yaml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   Nightly-Pgskipper-Pipeline:
-    uses: Netcracker/qubership-test-pipelines/.github/workflows/pgskipper.yaml@c46738acd2481dcea8b4cd0bee83e3f4f4539f2c #v1.11.0
+    uses: Netcracker/qubership-test-pipelines/.github/workflows/pgskipper.yaml@3e4193378da5730d7b96d3a625d22a158d5e8372 #v1.12.0
 
     with:
       repository_name: ${{ github.repository }}
       service_branch: '${{ github.head_ref || github.ref_name }}'
-      pipeline_branch: 'c46738acd2481dcea8b4cd0bee83e3f4f4539f2c' #this value must match the value after '@' in 'uses'
+      pipeline_branch: '3e4193378da5730d7b96d3a625d22a158d5e8372' #this value must match the value after '@' in 'uses'
       runner_type: 'ubuntu-latest'
       scope: 'nightly'
     secrets:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,11 +28,11 @@ jobs:
   Pgskipper-Pipeline:
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     needs: Wait-for-images
-    uses: Netcracker/qubership-test-pipelines/.github/workflows/pgskipper.yaml@c46738acd2481dcea8b4cd0bee83e3f4f4539f2c #v1.11.0
+    uses: Netcracker/qubership-test-pipelines/.github/workflows/pgskipper.yaml@3e4193378da5730d7b96d3a625d22a158d5e8372 #v1.12.0
     with:
       repository_name: ${{ github.repository }}
       service_branch: '${{ github.head_ref || github.ref_name }}'
-      pipeline_branch: 'c46738acd2481dcea8b4cd0bee83e3f4f4539f2c' #this value must match the value after '@' in 'uses'
+      pipeline_branch: '3e4193378da5730d7b96d3a625d22a158d5e8372' #this value must match the value after '@' in 'uses'
     secrets:
       AWS_S3_ACCESS_KEY_ID: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
       AWS_S3_ACCESS_KEY_SECRET: ${{secrets.AWS_S3_ACCESS_KEY_SECRET}}


### PR DESCRIPTION
Fix nightly pipeline:
https://github.com/Netcracker/pgskipper-operator/actions/runs/27105331010/workflow
<img width="1127" height="177" alt="image" src="https://github.com/user-attachments/assets/af7b1dbc-0682-4acc-ae4c-122d61bc9443" />

v1.11.0 does not contain the 'scope' parameter. Replaced with the correct one - v1.12.0
https://github.com/Netcracker/qubership-test-pipelines/releases/tag/v1.12.0
