### PR TITLE
fix: update nightly tests cron

### DIFF
--- a/.github/workflows/run_nightly_tests.yaml
+++ b/.github/workflows/run_nightly_tests.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 21 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   Nightly-Pgskipper-Pipeline:


### PR DESCRIPTION
Update the time at which the night tests are scheduled so that they start at the beginning of the day