### PR TITLE
refactor: update Helm charts release workflow and improve job configurations

### DIFF
--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -1,6 +1,6 @@
 ---
 
-name: Helm Charts Release 1
+name: Helm Charts Release
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/helm-charts-release.yaml
+++ b/.github/workflows/helm-charts-release.yaml
@@ -1,5 +1,6 @@
 ---
-name: Helm Charts Release
+
+name: Helm Charts Release 1
 on:
   workflow_dispatch:
     inputs:
@@ -7,24 +8,20 @@ on:
         description: 'Release version'
         required: true
         type: string
-
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 run-name: ${{ github.repository }} Release ${{ github.event.inputs.release }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   check-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Check if tag exists
         id: check_tag
-        uses: netcracker/qubership-workflow-hub/actions/tag-action@main
+        uses: netcracker/qubership-workflow-hub/actions/tag-action@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
         with:
           tag-name: '${{ inputs.release }}'
           ref: ${{ github.ref }}
@@ -32,20 +29,23 @@ jobs:
           check-tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   load-docker-build-components:
     runs-on: ubuntu-latest
     outputs:
       component: ${{ steps.load_component.outputs.components }}
       platforms: ${{ steps.load_component.outputs.platforms }}
+    env:
+      CONFIG_FILE: .github/build-config.cfg
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Load Docker Configuration
         id: load_component
-        run: |
-          verify=$(cat "$GITHUB_WORKSPACE/.github/build-config.cfg" | jq '
+        run:  |
+          verify=$(cat "$GITHUB_WORKSPACE/${CONFIG_FILE}" | jq '
           def verify_structure:
           .components as $components
           | .platforms as $platforms
@@ -56,12 +56,12 @@ jobs:
           | if . then true else false end
           ')
           if [ ${verify} == 'true' ]; then
-            echo "✅ $GITHUB_WORKSPACE/.github/build-config.cfg file is valid"
-            components=$(jq -c ".components" "$GITHUB_WORKSPACE/.github/build-config.cfg")
-            platforms=$(jq -c ".platforms" "$GITHUB_WORKSPACE/.github/build-config.cfg")
+            echo "✅ $GITHUB_WORKSPACE/${CONFIG_FILE} file is valid"
+            components=$(jq -c ".components" "$GITHUB_WORKSPACE/${CONFIG_FILE}")
+            platforms=$(jq -c ".platforms" "$GITHUB_WORKSPACE/${CONFIG_FILE}")
           else
-            echo "❗ $GITHUB_WORKSPACE/.github/build-config.cfg file is invalid"
-            echo "❗ $GITHUB_WORKSPACE/.github/build-config.cfg file is invalid" >> $GITHUB_STEP_SUMMARY
+            echo "❗ $GITHUB_WORKSPACE/${CONFIG_FILE} file is invalid"
+            echo "❗ $GITHUB_WORKSPACE/${CONFIG_FILE} file is invalid" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
           echo "components=${components}" >> $GITHUB_OUTPUT
@@ -69,7 +69,8 @@ jobs:
 
   docker-check-build:
     needs: [load-docker-build-components, check-tag]
-    runs-on: ubuntu-22.04
+    name: ${{ matrix.component.name }} dry run
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -80,43 +81,63 @@ jobs:
         run: |
           echo "IMAGE=${{ matrix.component.name }}" >> $GITHUB_ENV
       - name: Docker build
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@main
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
         with:
           ref: ${{ github.ref }}
           download-artifact: false
           dry-run: true
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ needs.load-docker-build-components.outputs.platforms }}
-          build-args: PG_VERSION=${{ matrix.component.pg_version }}
           tags: "${{ env.IMAGE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-  chart-release-prepare:
+  chart-release:
+    permissions:
+      contents: write
+      packages: write
     needs: [check-tag, load-docker-build-components, docker-check-build]
     runs-on: ubuntu-latest
     outputs:
       images-versions: ${{ steps.update-versions.outputs.images-versions }}
+      charts-artifact: ${{ steps.update-versions.outputs.released-chart-atrifact }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0
-      - name: "Update versions in values"
+          persist-credentials: true
+
+      - name: "Add github.vars into github.env"
+        env:
+          VARS_JSON: '${{ toJson(vars) }}'
+        run: |
+          echo "${VARS_JSON}" | jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' >> $GITHUB_ENV
+
+      - name: "Chart release"
         id: update-versions
-        uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@v2.0.1
+        uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
         with:
           release-version: ${{ inputs.release }}
           config-file: .github/charts-values-update-config.yaml
-        env:
-          ${{ insert }}: ${{ vars }}
+          default-tag: ${{ inputs.release }}
+          package-charts: true
+          publish-charts: true
+
       - name: "Debug"
+        env:
+          IMAGES_VERSIONS: "${{ steps.update-versions.outputs.images-versions }}"
         run: |
-          echo "Images versions: ${{ steps.update-versions.outputs.images-versions }}"
+          echo "Images versions: ${IMAGES_VERSIONS}"
+          ls -laR
 
   docker-build:
-    needs: [chart-release-prepare, load-docker-build-components]
-    runs-on: ubuntu-22.04
+    name: ${{ matrix.component.name }}
+    permissions:
+      contents: write
+      packages: write
+    needs: [chart-release, load-docker-build-components]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -124,63 +145,59 @@ jobs:
     steps:
       - name: Get version for current component
         id: get-version
+        env:
+          IMAGE_VER: "${{ fromJson(needs.chart-release.outputs.images-versions)[matrix.component.name] || inputs.release }}"
         run: |
-          echo "IMAGE_VERSION=${{ fromJson(needs.chart-release-prepare.outputs.images-versions)[matrix.component.name] || inputs.release }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${IMAGE_VER}" >> $GITHUB_ENV
 
       - name: Docker build
-        uses: netcracker/qubership-workflow-hub/actions/docker-action@main
+        uses: netcracker/qubership-workflow-hub/actions/docker-action@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
         with:
           ref: release-${{ inputs.release }}
           download-artifact: false
           dry-run: false
           component: ${{ toJson(matrix.component) }}
           platforms: ${{ needs.load-docker-build-components.outputs.platforms }}
-          build-args: PG_VERSION=${{ matrix.component.pg_version }}
           tags: "${{ env.IMAGE_VERSION }},latest"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-  charts-release:
-    needs: [docker-build]
+  github-release:
+    permissions:
+      contents: write
+      packages: write
+    needs: [chart-release, docker-build]
     continue-on-error: false
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: "Checkout code"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0
           ref: release-${{ inputs.release }}
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Run chart-releaser
-        uses: netcracker/chart-releaser-action@main
-        with:
-          charts_dir: operator/charts/
-          release_name_template: "{{ .Version }}"
-          skip_existing: true
-          skip_upload: true
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          persist-credentials: true
 
       - name: "Release-drafter"
-        uses: netcracker/release-drafter@master
+        uses: netcracker/release-drafter@v1.0.1
         with:
           config-name: release-drafter-config.yml
           publish: true
           name: ${{ inputs.release }}
           tag: ${{ inputs.release }}
           version: ${{ inputs.release }}
+          commitish: release-${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Assets
-        uses: netcracker/qubership-workflow-hub/actions/assets-action@v2.0.11
+      - name: "Download released charts"
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          artifact-ids: ${{ needs.chart-release.outputs.charts-artifact }}
+
+      - name: "Upload Assets"
+        uses: netcracker/qubership-workflow-hub/actions/assets-action@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
         with:
           tag: ${{ inputs.release }}
-          item-path: .cr-release-packages/*.tgz
+          item-path: "./*.tgz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaced chart-releaser action with our own action to release helm charts.
Release results changed:
❗In addition to release assets, released charts will be published into ghcr.io and available as on oci storage.
