### PR TITLE
feat: [CPCAP-10184] add label to pg secret

### DIFF
--- a/operator/charts/patroni-services/templates/secrets/postgres-secret.yaml
+++ b/operator/charts/patroni-services/templates/secrets/postgres-secret.yaml
@@ -6,6 +6,9 @@ metadata:
     app: patroni
     name: patroni
     automation.infra/secret-change: "true"
+    {{- if .Values.backupDaemon.install }}
+    cloud-backuper.netcracker.com/backup-daemon-credentials: "true"
+    {{- end }}
     {{ include "kubernetes.labels" . | nindent 4 }}
   name: postgres-credentials
 data:


### PR DESCRIPTION
Add label cloud-backuper.netcracker.com/backup-daemon-credentials: "true" to secret.
It will be used by cloud-backuper to call backup service with authentication.