### PR TITLE
fix: [PSUPCLCAP-4725] Update Patroni config map handling to use cluster-specific names and improve config map management

### DIFF
--- a/operator/controllers/patroni_core_controller.go
+++ b/operator/controllers/patroni_core_controller.go
@@ -274,7 +274,7 @@ func (pr *PatroniCoreReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{RequeueAfter: time.Minute}, err
 	}
 
-	if err := pr.helper.UpdatePatroniConfigMaps(); err != nil {
+	if err := pr.helper.UpdatePatroniConfigMaps(cr.Spec.Patroni.ClusterName); err != nil {
 		pr.logger.Error("error during update of patroni config maps", zap.Error(err))
 		return reconcile.Result{RequeueAfter: time.Minute}, err
 	}

--- a/operator/pkg/helper/resource_management.go
+++ b/operator/pkg/helper/resource_management.go
@@ -270,8 +270,15 @@ func (rm *ResourceManager) UpdateDaemonSet(ds *appsv1.DaemonSet) (err error) {
 	return nil
 }
 
-// Returns true if configMap was updated
 func (rm *ResourceManager) CreateOrUpdateConfigMap(cm *corev1.ConfigMap) (bool, error) {
+	return rm.createOrUpdateConfigMap(cm, false)
+}
+
+func (rm *ResourceManager) CreateOrUpdateManagedConfigMap(cm *corev1.ConfigMap) (bool, error) {
+	return rm.createOrUpdateConfigMap(cm, true)
+}
+
+func (rm *ResourceManager) createOrUpdateConfigMap(cm *corev1.ConfigMap, preserveLabels bool) (bool, error) {
 	foundCm := &corev1.ConfigMap{}
 	logger.Info(fmt.Sprintf("Start to check if %s cm exists", cm.Name))
 	err := rm.kubeClient.Get(context.TODO(), types.NamespacedName{
@@ -290,7 +297,7 @@ func (rm *ResourceManager) CreateOrUpdateConfigMap(cm *corev1.ConfigMap) (bool, 
 		if !reflect.DeepEqual(foundCm, cm) || !reflect.DeepEqual(foundCm.Data, cm.Data) {
 			logger.Info(fmt.Sprintf("Updating %s k8s cm", cm.Name))
 			cm.OwnerReferences = rm.GetOwnerReferences()
-			if cm.Name != "patroni-leader" && cm.Name != "patroni-config" {
+			if !preserveLabels {
 				cm.Labels = rm.getLabels(cm.ObjectMeta)
 			}
 			err = rm.kubeClient.Update(context.TODO(), cm)
@@ -693,8 +700,8 @@ func (rm *ResourceManager) UpdatePGService() error {
 	return nil
 }
 
-func (rm *ResourceManager) UpdatePatroniConfigMaps() error {
-	var configMaps = []string{"patroni-leader", "patroni-config"}
+func (rm *ResourceManager) UpdatePatroniConfigMaps(clusterName string) error {
+	var configMaps = []string{fmt.Sprintf("%s-leader", clusterName), fmt.Sprintf("%s-config", clusterName)}
 	for _, configMap := range configMaps {
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			cmap, err := rm.GetConfigMap(configMap)
@@ -702,7 +709,7 @@ func (rm *ResourceManager) UpdatePatroniConfigMaps() error {
 				return err
 			}
 			cmap.ObjectMeta.OwnerReferences = rm.GetOwnerReferences()
-			_, err = rm.CreateOrUpdateConfigMap(cmap)
+			_, err = rm.CreateOrUpdateManagedConfigMap(cmap)
 			return err
 		})
 		if err != nil {

--- a/operator/pkg/reconciler/patroni.go
+++ b/operator/pkg/reconciler/patroni.go
@@ -380,7 +380,7 @@ func (r *PatroniReconciler) Reconcile() error {
 		}
 	}
 
-	for _, name := range []string{"patroni-config", "patroni-leader"} {
+	for _, name := range []string{fmt.Sprintf("%s-config", r.cluster.ClusterName), fmt.Sprintf("%s-leader", r.cluster.ClusterName)} {
 		cm, err := r.helper.GetConfigMap(name)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -398,7 +398,7 @@ func (r *PatroniReconciler) Reconcile() error {
 				cm.Annotations[k] = v
 			}
 		}
-		if _, err := r.helper.CreateOrUpdateConfigMap(cm); err != nil {
+		if _, err := r.helper.CreateOrUpdateManagedConfigMap(cm); err != nil {
 			logger.Error("failed to annotate Patroni ConfigMap", zap.Error(err))
 			return err
 		}

--- a/services/backup-daemon/maintenance/recovery/pg_back_rest_recovery.py
+++ b/services/backup-daemon/maintenance/recovery/pg_back_rest_recovery.py
@@ -103,7 +103,7 @@ class PgBackRestRecovery():
             log.info("Delete leader cm")
             body = client.V1DeleteOptions()
             core_api = client.CoreV1Api(self._api_client)
-            core_api.delete_namespaced_config_map("patroni-leader", self.project, body=body,)
+            core_api.delete_namespaced_config_map(f"{pg_cluster_name}-leader", self.project, body=body,)
         except kubernetes.client.rest.ApiException as e:
             if e.reason == "Not Found":
                 return
@@ -114,7 +114,7 @@ class PgBackRestRecovery():
         log.info("Delete initialize key")
         cmaps = client.CoreV1Api(self._api_client).list_namespaced_config_map(self.project).items
         for cm in cmaps:
-            if cm.metadata.name == 'patroni-config':
+            if cm.metadata.name == f'{pg_cluster_name}-config':
                 if "initialize" in cm.metadata.annotations:
                     del cm.metadata.annotations["initialize"]
                     self.patch_configmap(cm.metadata.name, cm)


### PR DESCRIPTION
- Refactor UpdatePatroniConfigMaps to accept clusterName parameter
- Introduce CreateOrUpdateManagedConfigMap for better config map handling
- Update references to config maps in reconciler and recovery scripts to use cluster-specific names